### PR TITLE
Make user account info consistent with ruby norms

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,28 +39,34 @@ touch .config.yml
 Into that file you'll need to add as a minimum this
 
 ```yaml
-custom:
-  accounts:
-    Admin:
-      username: admin@example.com
-      password: please123
-    account2:
-      username: account2@example.com
-      password: please123
-  urls:
-    front_office: "https://example.com"
-    back_office: "https://example.com"
-
-# Changes user agent
-user_agent: "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
-
 # Capybara will attempt to find an element for a period of time, rather than
 # immediately failing because the element cannot be found. This defaults to 2
-# seconds. 
-max_wait_time: 2
+# seconds but with the need to confirm emails via mailinator, we have found we
+# need to increase this time to at least 5 seconds 
+max_wait_time: 5
+
+custom:
+  accounts:
+    agency_user:
+      username: agency_user@example.gov.uk
+      password: Password1234
+    finance_admin:
+      username: finance_admin@example.gov.uk
+      password: Password1234
+    finance_basic:
+      username: finance_basic@example.gov.uk
+      password: Password1234
+    agency_user_with_payment_refund:
+      username: agency_user_with_payment_refund@example.gov.uk
+      password: Password1234
+  urls:
+    front_office: "http://domainundertest.gov.uk/registrations/start"
+    back_office: "http://domainundertest.gov.uk/agency_users/sign_in"
+    back_office_admin: "http://domainundertest.gov.uk/admins/sign_in"
+    mail_checker: "https://www.mailinator.com"
 ```
 
-If left as that by default when **Quke** is executed it will run against your selected environment using the headless browser **PhantomJS**. You can however override this and over values using the standard [Quke configuration options](https://github.com/DEFRA/quke#configuration).
+If left as that by default when **Quke** is executed it will run against your selected environment using the headless browser **PhantomJS**. You can however override this and other values using the standard [Quke configuration options](https://github.com/DEFRA/quke#configuration).
 
 ## Execution
 

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -2,8 +2,8 @@ Given(/^an Environment Agency user has signed in$/) do
   @app = BackOfficeApp.new
   @app.login_page.load
   @app.login_page.submit(
-    email: Quke::Quke.config.custom["accounts"]["AgencyUser"]["username"],
-    password: Quke::Quke.config.custom["accounts"]["AgencyUser"]["password"]
+    email: Quke::Quke.config.custom["accounts"]["agency_user"]["username"],
+    password: Quke::Quke.config.custom["accounts"]["agency_user"]["password"]
   )
 end
 
@@ -11,8 +11,8 @@ Given(/^I am signed in as a finance admin$/) do
   @app = BackOfficeApp.new
   @app.login_page.load
   @app.login_page.submit(
-    email: Quke::Quke.config.custom["accounts"]["FinanceAdmin"]["username"],
-    password: Quke::Quke.config.custom["accounts"]["FinanceAdmin"]["password"]
+    email: Quke::Quke.config.custom["accounts"]["finance_admin"]["username"],
+    password: Quke::Quke.config.custom["accounts"]["finance_admin"]["password"]
   )
 end
 
@@ -20,8 +20,8 @@ Given(/^I am signed in as a finance user$/) do
   @app = BackOfficeApp.new
   @app.login_page.load
   @app.login_page.submit(
-    email: Quke::Quke.config.custom["accounts"]["FinanceBasic"]["username"],
-    password: Quke::Quke.config.custom["accounts"]["FinanceBasic"]["password"]
+    email: Quke::Quke.config.custom["accounts"]["finance_basic"]["username"],
+    password: Quke::Quke.config.custom["accounts"]["finance_basic"]["password"]
   )
 end
 
@@ -29,8 +29,8 @@ Given(/^I am signed in as an Environment Agency user with refunds$/) do
   @app = BackOfficeApp.new
   @app.login_page.load
   @app.login_page.submit(
-    email: Quke::Quke.config.custom["accounts"]["AgencyUserWithPaymentRefund"]["username"],
-    password: Quke::Quke.config.custom["accounts"]["AgencyUserWithPaymentRefund"]["password"]
+    email: Quke::Quke.config.custom["accounts"]["agency_user_with_payment_refund"]["username"],
+    password: Quke::Quke.config.custom["accounts"]["agency_user_with_payment_refund"]["password"]
   )
 end
 


### PR DESCRIPTION
Simple change to the way the tests expect the details for the different back office user accounts to be held. Essentially lower snake case rather than camel case.

Also includes an update to the README to details these requirements.