### PR TITLE
Add change account email feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ To have consistency across the project the following tags are defined and should
 |@backoffice|Any feature or scenario expected to be run against the back office Dynamics application|
 |@happypath|A scenario which details a complete registration with no errors|
 |@functional|Any feature or scenario which is testing just a specific function of the service e.g. validation errors|
+|@broken|A scenario which is known to be broken due to the service not meeting expected behaviour|
 |@ci|A feature that is intended to be run only on our continuous integration service (you should never need to use this tag).|
 
 It's also common practice to use a custom tag whilst working on a new feature or scenario e.g. `@focus` or `@wip`. That is perfectly acceptable but please ensure they are removed before your change is merged.

--- a/features/back_office/change_account_email.feature
+++ b/features/back_office/change_account_email.feature
@@ -1,0 +1,16 @@
+@backoffice @functional
+Feature: Change the account email for registrations
+As an agency user
+I need to be able to change the account linked to a registration
+So that users can continue to maintain registrations even if their details change
+
+  Scenario: Change the account where user has just one registration
+    Given the user has one registration
+     When I change the account email
+     Then I see a confirmation the change has been made
+
+  @broken
+  Scenario: Change the account where user has just multiple registrations
+    Given the user has 2 registrations
+     When I change the account email for both
+     Then I see a confirmation for both

--- a/features/page_objects/back_office/back_office_app.rb
+++ b/features/page_objects/back_office/back_office_app.rb
@@ -107,6 +107,10 @@ class BackOfficeApp
     @last_page = PaymentsPage.new
   end
 
+  def edit_account_email_page
+    @last_page = EditAccountEmailPage.new
+  end
+
   def mailinator_page
     @last_page = MailinatorPage.new
   end

--- a/features/page_objects/back_office/edit_account_email_page.rb
+++ b/features/page_objects/back_office/edit_account_email_page.rb
@@ -1,0 +1,17 @@
+class EditAccountEmailPage < SitePrism::Page
+
+  element(:notice, ".validation-summary.notice")
+  element(:back_link, "a[href*='/registrations']")
+
+  # Cannot simply use the CSS # id selector because there are 2 elements on the
+  # page with this id; one a div the other an input
+  element(:email_address, "input[id='registration_accountEmail']")
+
+  element(:submit_button, "#continue")
+
+  def submit(args = {})
+    email_address.set(args[:email]) if args.key?(:email)
+
+    submit_button.click
+  end
+end

--- a/features/page_objects/back_office/finish_assisted_page.rb
+++ b/features/page_objects/back_office/finish_assisted_page.rb
@@ -5,4 +5,10 @@ class FinishAssistedPage < SitePrism::Page
   element(:access_code, "#accessCode")
   element(:view_certificate, "#view_certificate")
 
+  element(:submit_button, "#finished_btn")
+
+  def submit(_args = {})
+    submit_button.click
+  end
+
 end

--- a/features/page_objects/back_office/registrations_page.rb
+++ b/features/page_objects/back_office/registrations_page.rb
@@ -9,6 +9,14 @@ class RegistrationsPage < SitePrism::Page
 
   element(:sign_out, "#signout_button")
 
+  sections :search_results, ".agency-edit" do
+    element(:view_certificate, "a[href*='view']")
+    element(:edit_registration, "a[href*='edit_process']")
+    element(:change_account_email, "a[href*='edit_account_email']")
+    element(:de_register, "a[href*='confirm_delete']")
+    element(:revoke, "a[href*='revoke']")
+  end
+
   def search(args = {})
     search_input.set(args[:search_input]) if args.key?(:search_input)
     reg_search.click

--- a/features/page_objects/front_office_app.rb
+++ b/features/page_objects/front_office_app.rb
@@ -51,6 +51,10 @@ class FrontOfficeApp
     @last_page = SignupPage.new
   end
 
+  def sign_in_page
+    @last_page = SignInPage.new
+  end
+
   def confirm_account_page
     @last_page = ConfirmAccountPage.new
   end

--- a/features/page_objects/sign_in_page.rb
+++ b/features/page_objects/sign_in_page.rb
@@ -1,0 +1,16 @@
+class SignInPage < SitePrism::Page
+
+  # Cannot simply use the CSS # id selector because there are 2 elements on the
+  # page with this id; one a div the other an input
+  element(:email_address, "input[id='registration_accountEmail']")
+  element(:password, "input[id='registration_password']")
+
+  element(:submit_button, "#continue")
+
+  def submit(args = {})
+    email_address.set(args[:email]) if args.key?(:email)
+    password.set(args[:password]) if args.key?(:password)
+
+    submit_button.click
+  end
+end

--- a/features/step_definitions/back_office/change_account_email_steps.rb
+++ b/features/step_definitions/back_office/change_account_email_steps.rb
@@ -1,0 +1,161 @@
+require "faker"
+
+Given(/^the user has one registration$/) do
+  @front_app = FrontOfficeApp.new
+  @front_app.start_page.load
+  @front_app.start_page.submit
+  @front_app.business_type_page.submit(org_type: "charity")
+
+  @front_app.business_details_page.submit(
+    company_name: Faker::Company.name,
+    postcode: "BS1 5AH",
+    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+  )
+
+  @email = @front_app.generate_email
+  @front_app.contact_details_page.submit(
+    first_name: Faker::Name.first_name,
+    last_name: Faker::Name.last_name,
+    phone_number: "012345678",
+    email: @email
+  )
+
+  @front_app.postal_address_page.submit
+  @front_app.declaration_page.submit
+
+  @front_app.sign_up_page.submit(
+    registration_password: "Secret123",
+    confirm_password: "Secret123",
+    confirm_email: @email
+  )
+
+  @front_app.mailinator_page.load
+  @front_app.mailinator_page.submit(inbox: @email)
+  @front_app.mailinator_inbox_page.confirmation_email.click
+  @front_app.mailinator_inbox_page.email_details do |frame|
+    @new_window = window_opened_by { frame.confirm_email.click }
+  end
+
+  within_window @new_window do
+    @registration = @front_app.registration_confirmed_page.registration_number.text
+  end
+end
+
+Given(/^the user has 2 registrations$/) do
+  @front_app = FrontOfficeApp.new
+  @first_name = Faker::Name.first_name
+  @last_name = Faker::Name.last_name
+  @email = @front_app.generate_email
+  @registrations = []
+
+  @front_app.start_page.load
+  @front_app.start_page.submit
+  @front_app.business_type_page.submit(org_type: "charity")
+
+  @front_app.business_details_page.submit(
+    company_name: Faker::Company.name,
+    postcode: "BS1 5AH",
+    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+  )
+
+  @front_app.contact_details_page.submit(
+    first_name: @first_name,
+    last_name: @last_name,
+    phone_number: "012345678",
+    email: @email
+  )
+
+  @front_app.postal_address_page.submit
+  @front_app.declaration_page.submit
+
+  @front_app.sign_up_page.submit(
+    registration_password: "Secret123",
+    confirm_password: "Secret123",
+    confirm_email: @email
+  )
+
+  @front_app.mailinator_page.load
+  @front_app.mailinator_page.submit(inbox: @email)
+  @front_app.mailinator_inbox_page.confirmation_email.click
+  @front_app.mailinator_inbox_page.email_details do |frame|
+    @new_window = window_opened_by { frame.confirm_email.click }
+  end
+
+  within_window @new_window do
+    @registrations << @front_app.registration_confirmed_page.registration_number.text
+  end
+
+  @front_app.start_page.load
+  @front_app.start_page.submit
+  @front_app.business_type_page.submit(org_type: "charity")
+
+  @front_app.business_details_page.submit(
+    company_name: Faker::Company.name,
+    postcode: "BS1 5AH",
+    result: "ENVIRONMENT AGENCY, HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
+  )
+
+  @front_app.contact_details_page.submit(
+    first_name: @first_name,
+    last_name: @last_name,
+    phone_number: "012345678",
+    email: @email
+  )
+
+  @front_app.postal_address_page.submit
+  @front_app.declaration_page.submit
+
+  @front_app.sign_in_page.submit(
+    password: "Secret123"
+  )
+
+  @registrations << @front_app.registration_confirmed_page.registration_number.text
+end
+
+When(/^I change the account email$/) do
+  @back_app = BackOfficeApp.new
+  @back_app.login_page.load
+  @back_app.login_page.submit(
+    email: Quke::Quke.config.custom["accounts"]["agency_user"]["username"],
+    password: Quke::Quke.config.custom["accounts"]["agency_user"]["password"]
+  )
+
+  @back_app.registrations_page.search(search_input: @registration)
+  @back_app.registrations_page.search_results[0].change_account_email.click
+
+  @new_email = @front_app.generate_email
+  @back_app.edit_account_email_page.submit(email: @new_email)
+end
+
+When(/^I change the account email for both$/) do
+  Capybara.reset_sessions!
+  @back_app = BackOfficeApp.new
+  @back_app.login_page.load
+  @back_app.login_page.submit(
+    email: Quke::Quke.config.custom["accounts"]["agency_user"]["username"],
+    password: Quke::Quke.config.custom["accounts"]["agency_user"]["password"]
+  )
+
+  @registrations.each do |reg_no|
+    @back_app.registrations_page.search(search_input: reg_no)
+    @back_app.registrations_page.search_results[0].change_account_email.click
+
+    @new_email = @front_app.generate_email
+    @back_app.edit_account_email_page.submit(email: @new_email)
+
+    expect(@back_app.edit_account_email_page).to have_notice
+
+    @back_app.edit_account_email_page.back_link.click
+  end
+end
+
+Then(/^I see a confirmation the change has been made$/) do
+  expect(@back_app.edit_account_email_page).to have_notice
+end
+
+Then(/^I see a confirmation for both$/) do
+  # I do nothing. The expect() call actually takes place in
+  # `I change the account email for both` because there is no way to see the
+  # notice other than at the time of making the change.
+  # Having this step just makes the scenario read better :-)
+end

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -7,6 +7,15 @@ Given(/^an Environment Agency user has signed in$/) do
   )
 end
 
+Given(/^an agency user has signed in$/) do
+  @app = BackOfficeApp.new
+  @app.login_page.load
+  @app.login_page.submit(
+    email: Quke::Quke.config.custom["accounts"]["agency_user"]["username"],
+    password: Quke::Quke.config.custom["accounts"]["agency_user"]["password"]
+  )
+end
+
 Given(/^I am signed in as a finance admin$/) do
   @app = BackOfficeApp.new
   @app.login_page.load


### PR DESCRIPTION
This change adds the feature and related steps to support testing the change account functionality.

At the time of adding we know that if you change the account on a registration for a user that has multiple registrations, it will work for that one but you then won't be able to change it for the others.