### PR TITLE
Add new rake task and docs to reset vagrant db

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This project is setup to run against version 2.2.3 of Ruby.
 
 The rest of the pre-requisites are the same as those for [Quke](https://github.com/DEFRA/quke#pre-requisites).
 
+Also some of the [rake](https://github.com/ruby/rake) tasks (to see the available list call `bundle exec rake -T`) and `config.yml` files assume you have the Waste Carriers [Vagrant](https://www.vagrantup.com/) environment running locally. Contact [Alan Cruikshanks](https://github.com/Cruikshanks) or [Tim Stone](https://github.com/timstone) for details if unsure.
+
 ## Installation
 
 First clone the repository and then drop into your new local repo
@@ -42,7 +44,7 @@ Into that file you'll need to add as a minimum this
 # Capybara will attempt to find an element for a period of time, rather than
 # immediately failing because the element cannot be found. This defaults to 2
 # seconds but with the need to confirm emails via mailinator, we have found we
-# need to increase this time to at least 5 seconds 
+# need to increase this time to at least 5 seconds
 max_wait_time: 5
 
 custom:
@@ -68,6 +70,19 @@ custom:
 ```
 
 If left as that by default when **Quke** is executed it will run against your selected environment using the headless browser **PhantomJS**. You can however override this and other values using the standard [Quke configuration options](https://github.com/DEFRA/quke#configuration).
+
+### VAGRANT_KEY_LOCATION
+
+You will also need to set the environment variable `VAGRANT_KEY_LOCATION` to the path to your Vagrant environment private key location. This links to the rake task `reset` which a number of other rake tasks depend on.
+
+Go to the root of the Waste Carriers vagrant project and then run the following
+
+```bash
+cd .vagrant/machines/development/virtualbox/
+pwd
+```
+
+The final command should output a value like `/Users/myusername/wcr-vagrant/.vagrant/machines/development/virtualbox`. Add it to your `~/.bash_profile` (open the file and add the line `export VAGRANT_KEY_LOCATION="/Users/myusername/wcr-vagrant/.vagrant/machines/development/virtualbox"`). You'll only have to do this once and then it'll be available always.
 
 ## Execution
 

--- a/README.md
+++ b/README.md
@@ -51,16 +51,12 @@ custom:
   accounts:
     agency_user:
       username: agency_user@example.gov.uk
-      password: Password1234
     finance_admin:
       username: finance_admin@example.gov.uk
-      password: Password1234
     finance_basic:
       username: finance_basic@example.gov.uk
-      password: Password1234
     agency_user_with_payment_refund:
       username: agency_user_with_payment_refund@example.gov.uk
-      password: Password1234
   urls:
     front_office: "http://domainundertest.gov.uk/registrations/start"
     front_office_sign_in: "http://domainundertest.gov.uk/users/sign_in?locale=en"
@@ -70,6 +66,12 @@ custom:
 ```
 
 If left as that by default when **Quke** is executed it will run against your selected environment using the headless browser **PhantomJS**. You can however override this and other values using the standard [Quke configuration options](https://github.com/DEFRA/quke#configuration).
+
+### WASTECARRIERSPASSWORD
+
+You will also need to set the environment variable `WASTECARRIERSPASSWORD` before running any tests. Its best practise not to include credentials within source code, so we have not included them in the `.config.yml` files attached to this project. However a number of the scenarios depend on being logged in, and therefore need to be able to access the password. Setting this environment variable is how they access it.
+
+Add it to your `~/.bash_profile` (open the file and add the line `export WASTECARRIERSPASSWORD="mySuperStr0ngPassword"`). You'll only have to do this once and then it'll be available always.
 
 ### VAGRANT_KEY_LOCATION
 

--- a/Rakefile
+++ b/Rakefile
@@ -24,6 +24,25 @@ task :wip do
   sh %( QUKE_CONFIG=.config_galaxyS8.yml bundle exec quke --tags @wip)
 end
 
+desc "Run any WIP after resetting the database"
+task clean_wip: [:reset] do
+  sh %( QUKE_CONFIG=.config.yml bundle exec quke --tags @wip)
+end
+
+# rubocop:disable Metrics/LineLength
+desc "Reset the database in the vagrant environment"
+task :reset do
+  vagrant_loc = ENV["VAGRANT_KEY_LOCATION"]
+  raise ArgumentError, "Environment variable VAGRANT_KEY_LOCATION not set" if vagrant_loc.nil? || vagrant_loc.empty?
+
+  vagrant_key = File.join(vagrant_loc, "private_key")
+  cmd = "ssh -i #{vagrant_key} vagrant@192.168.33.11 'cd /vagrant/waste-carriers-renewals && export PATH=\"$HOME/.rbenv/bin:$PATH\" && eval \"$(rbenv init -)\" && bundle exec rake db:reset'"
+  system(cmd)
+
+  puts "Databases reset"
+end
+# rubocop:enable Metrics/LineLength
+
 desc "Runs the tests used by continuous integration to check the project"
 task :ci do
   Rake::Task["rubocop"].invoke


### PR DESCRIPTION
As a first step to being able to create a rake task that can cycle through a range of tests automatically we needed a way of resetting the database between each run. The [waste-carriers-renewals](https://github.com/DEFRA/waste-carriers-renewals) project already includes one to perform the reset. The acceptance tests just needed a way to call it on the Vagrant box.

So this change adds a new rake task called `reset` which calls the command on the Vagrant box using ssh. It also updates the README to provide details about it and what configuration is needed to support.