### PR TITLE
Remove references to elasticsearch

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -175,11 +175,6 @@ task :reset_registrations_db do
   reset_registrations
 end
 
-desc "Reindex elastic search"
-task :elastic_search do
-  elastic_search
-end
-
 # rubocop:disable Metrics/LineLength
 def reset_renewals
   vagrant_loc = ENV["VAGRANT_KEY_LOCATION"]
@@ -206,16 +201,5 @@ def reset_registrations
   end
 
   puts "Databases reset"
-end
-
-def elastic_search
-  vagrant_loc = ENV["VAGRANT_KEY_LOCATION"]
-  raise ArgumentError, "Environment variable VAGRANT_KEY_LOCATION not set" if vagrant_loc.nil? || vagrant_loc.empty?
-
-  vagrant_key = File.join(vagrant_loc, "private_key")
-  cmd = "ssh -i #{vagrant_key} vagrant@192.168.33.11 'cd /vagrant/waste-carriers-service/bin && WCRS_SERVICES_ADMIN_PORT=9091 . reindex_elasticsearch.sh'"
-  system(cmd)
-
-  puts "Elastic search reindexed"
 end
 # rubocop:enable Metrics/LineLength

--- a/features/page_objects/back_office/registrations_page.rb
+++ b/features/page_objects/back_office/registrations_page.rb
@@ -39,7 +39,7 @@ class RegistrationsPage < SitePrism::Page
       if search_results[0].status.text == text_to_check
         refresh_cnt = 360
       else
-        # reloads the page if service layer hasn't updated elastic search in time
+        # reloads the page if service layer hasn't updated in time
         page.evaluate_script("window.location.reload()")
         sleep(1)
         refresh_cnt += 1


### PR DESCRIPTION
Elasticsearch is no longer part of the service so any attempts to interact with it will fail.

Hence this changes removes any reference to elasticsearch from the project.