### PR TITLE
Standardise environment variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # Environment Variables for the Waste Carriers acceptance tests.
 
-WASTECARRIERSPASSWORD='Secret123'
+WCRS_DEFAULT_PASSWORD='Secret123'

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ custom:
 
 If left as that by default when **Quke** is executed it will run against your selected environment using the headless browser **PhantomJS**. You can however override this and other values using the standard [Quke configuration options](https://github.com/DEFRA/quke#configuration).
 
-### WASTECARRIERSPASSWORD
+### WCRS_DEFAULT_PASSWORD
 
-You will also need to set the environment variable `WASTECARRIERSPASSWORD` before running any tests. Its best practise not to include credentials within source code, so we have not included them in the `.config.yml` files attached to this project. However a number of the scenarios depend on being logged in, and therefore need to be able to access the password. Setting this environment variable is how they access it.
+You will also need to set the environment variable `WCRS_DEFAULT_PASSWORD` before running any tests. Its best practise not to include credentials within source code, so we have not included them in the `.config.yml` files attached to this project. However a number of the scenarios depend on being logged in, and therefore need to be able to access the password. Setting this environment variable is how they access it.
 
-Add it to your `~/.bash_profile` (open the file and add the line `export WASTECARRIERSPASSWORD="mySuperStr0ngPassword"`). You'll only have to do this once and then it'll be available always.
+Add it to your `~/.bash_profile` (open the file and add the line `export WCRS_DEFAULT_PASSWORD="mySuperStr0ngPassword"`). You'll only have to do this once and then it'll be available always.
 
 ### VAGRANT_KEY_LOCATION
 

--- a/features/step_definitions/back_office/change_account_email_steps.rb
+++ b/features/step_definitions/back_office/change_account_email_steps.rb
@@ -33,8 +33,8 @@ Given(/^the user has 2 registrations$/) do
   @front_app.check_details_page.submit
 
   @front_app.sign_up_page.submit(
-    registration_password: ENV["WASTECARRIERSPASSWORD"],
-    confirm_password: ENV["WASTECARRIERSPASSWORD"],
+    registration_password: ENV["WCRS_DEFAULT_PASSWORD"],
+    confirm_password: ENV["WCRS_DEFAULT_PASSWORD"],
     confirm_email: @email_address
   )
   @front_app.start_page.load
@@ -58,7 +58,7 @@ Given(/^the user has 2 registrations$/) do
   @front_app.check_details_page.submit
 
   @front_app.waste_carrier_sign_in_page.submit(
-    password: ENV["WASTECARRIERSPASSWORD"]
+    password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
 
   @registrations << @front_app.confirmation_page.registration_number.text
@@ -69,7 +69,7 @@ When(/^I change the account email$/) do
   @back_app.agency_sign_in_page.load
   @back_app.agency_sign_in_page.submit(
     email: Quke::Quke.config.custom["accounts"]["agency_user"]["username"],
-    password: ENV["WASTECARRIERSPASSWORD"]
+    password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
 
   @back_app.registrations_page.search(search_input: @registration)
@@ -85,7 +85,7 @@ When(/^I change the account email for both$/) do
   @back_app.agency_sign_in_page.load
   @back_app.agency_sign_in_page.submit(
     email: Quke::Quke.config.custom["accounts"]["agency_user"]["username"],
-    password: ENV["WASTECARRIERSPASSWORD"]
+    password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
 
   @registrations.each do |reg_no|

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -3,7 +3,7 @@ Given(/^an Environment Agency user has signed in$/) do
   @back_app.agency_sign_in_page.load
   @back_app.agency_sign_in_page.submit(
     email: Quke::Quke.config.custom["accounts"]["agency_user"]["username"],
-    password: ENV["WASTECARRIERSPASSWORD"]
+    password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
 end
 
@@ -12,7 +12,7 @@ Given(/^I am signed in as an Environment Agency user with refunds$/) do
   @back_app.agency_sign_in_page.load
   @back_app.agency_sign_in_page.submit(
     email: Quke::Quke.config.custom["accounts"]["agency_user_with_payment_refund"]["username"],
-    password: ENV["WASTECARRIERSPASSWORD"]
+    password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
 end
 
@@ -21,7 +21,7 @@ Given(/^I am signed in as a finance admin$/) do
   @back_app.agency_sign_in_page.load
   @back_app.agency_sign_in_page.submit(
     email: Quke::Quke.config.custom["accounts"]["finance_admin"]["username"],
-    password: ENV["WASTECARRIERSPASSWORD"]
+    password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
 end
 
@@ -30,7 +30,7 @@ Given(/^I am signed in as a finance user$/) do
   @back_app.agency_sign_in_page.load
   @back_app.agency_sign_in_page.submit(
     email: Quke::Quke.config.custom["accounts"]["finance_basic"]["username"],
-    password: ENV["WASTECARRIERSPASSWORD"]
+    password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
 end
 
@@ -142,7 +142,7 @@ Then(/^my registration status for "([^"]*)" will be "([^"]*)"$/) do |search_item
   @back_app.agency_sign_in_page.load
   @back_app.agency_sign_in_page.submit(
     email: Quke::Quke.config.custom["accounts"]["agency_user"]["username"],
-    password: ENV["WASTECARRIERSPASSWORD"]
+    password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
   @back_app.registrations_page.search(search_input: search_item)
   expect(@back_app.registrations_page.search_results[0].status.text).to eq(status)
@@ -155,7 +155,7 @@ Then(/^(?:the|my) registration status will be "([^"]*)"$/) do |status|
   @back_app.agency_sign_in_page.load
   @back_app.agency_sign_in_page.submit(
     email: Quke::Quke.config.custom["accounts"]["agency_user"]["username"],
-    password: ENV["WASTECARRIERSPASSWORD"]
+    password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
   @back_app.registrations_page.search(search_input: @registration_number)
   @back_app.registrations_page.wait_for_status(status)

--- a/features/step_definitions/back_office/upper_tier/assisted_digital_renewal_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/assisted_digital_renewal_steps.rb
@@ -3,7 +3,7 @@ Given(/^I have my public body upper tier registration completed for me$/) do
   @back_app.agency_sign_in_page.load
   @back_app.agency_sign_in_page.submit(
     email: Quke::Quke.config.custom["accounts"]["agency_user"]["username"],
-    password: ENV["WASTECARRIERSPASSWORD"]
+    password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
   @back_app.registrations_page.new_registration.click
   @back_app.start_page.submit

--- a/features/step_definitions/back_office/upper_tier/conviction_checks_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/conviction_checks_steps.rb
@@ -24,7 +24,7 @@ Then(/^the registration has a "([^"]*)" status$/) do |status|
   @back_app.agency_sign_in_page.load
   @back_app.agency_sign_in_page.submit(
     email: Quke::Quke.config.custom["accounts"]["agency_user"]["username"],
-    password: ENV["WASTECARRIERSPASSWORD"]
+    password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
   @back_app.registrations_page.search(search_input: @registration_number)
   @back_app.registrations_page.wait_for_status(status)

--- a/features/step_definitions/front_office/delete_registration_steps.rb
+++ b/features/step_definitions/front_office/delete_registration_steps.rb
@@ -4,7 +4,7 @@ Given(/I choose to delete my registration "([^"]*)"$/) do |reg_no|
   @front_app.waste_carrier_sign_in_page.load
   @front_app.waste_carrier_sign_in_page.submit(
     email: Quke::Quke.config.custom["accounts"]["waste_carrier2"]["username"],
-    password: ENV["WASTECARRIERSPASSWORD"]
+    password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
   @registration_number = reg_no
 

--- a/features/step_definitions/front_office/general_steps.rb
+++ b/features/step_definitions/front_office/general_steps.rb
@@ -72,6 +72,6 @@ When(/^I have signed into my account$/) do
   @front_app.waste_carrier_sign_in_page.load
   @front_app.waste_carrier_sign_in_page.submit(
     email: @email_address,
-    password: ENV["WASTECARRIERSPASSWORD"]
+    password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
 end

--- a/features/step_definitions/front_office/ir_renewal_steps.rb
+++ b/features/step_definitions/front_office/ir_renewal_steps.rb
@@ -46,8 +46,8 @@ When(/^I complete the public body registration renewal$/) do
   @front_app.relevant_convictions_page.submit(choice: :no)
   @front_app.check_details_page.submit
   @front_app.sign_up_page.submit(
-    registration_password: ENV["WASTECARRIERSPASSWORD"],
-    confirm_password: ENV["WASTECARRIERSPASSWORD"],
+    registration_password: ENV["WCRS_DEFAULT_PASSWORD"],
+    confirm_password: ENV["WCRS_DEFAULT_PASSWORD"],
     confirm_email: @email_address
   )
   @front_app.order_page.submit(

--- a/features/step_definitions/front_office/limited_company_new_upper_tier_registration_steps.rb
+++ b/features/step_definitions/front_office/limited_company_new_upper_tier_registration_steps.rb
@@ -27,8 +27,8 @@ When(/^I complete my application of my limited company as an upper tier waste ca
   @front_app.relevant_convictions_page.submit(choice: :no)
   @front_app.check_details_page.submit
   @front_app.sign_up_page.submit(
-    registration_password: ENV["WASTECARRIERSPASSWORD"],
-    confirm_password: ENV["WASTECARRIERSPASSWORD"],
+    registration_password: ENV["WCRS_DEFAULT_PASSWORD"],
+    confirm_password: ENV["WCRS_DEFAULT_PASSWORD"],
     confirm_email: @email_address
   )
 end
@@ -66,8 +66,8 @@ Given(/^(?:my|a) limited company with companies house number "([^"]*)" registers
   @front_app.relevant_convictions_page.submit(choice: :no)
   @front_app.check_details_page.submit
   @front_app.sign_up_page.submit(
-    registration_password: ENV["WASTECARRIERSPASSWORD"],
-    confirm_password: ENV["WASTECARRIERSPASSWORD"],
+    registration_password: ENV["WCRS_DEFAULT_PASSWORD"],
+    confirm_password: ENV["WCRS_DEFAULT_PASSWORD"],
     confirm_email: @email_address
   )
   @front_app.order_page.submit(

--- a/features/step_definitions/front_office/new_lower_tier_registration_steps.rb
+++ b/features/step_definitions/front_office/new_lower_tier_registration_steps.rb
@@ -19,8 +19,8 @@ When(/^I complete my application of my charity as a lower tier waste carrier$/) 
   @front_app.check_details_page.submit
 
   @front_app.sign_up_page.submit(
-    registration_password: ENV["WASTECARRIERSPASSWORD"],
-    confirm_password: ENV["WASTECARRIERSPASSWORD"],
+    registration_password: ENV["WCRS_DEFAULT_PASSWORD"],
+    confirm_password: ENV["WCRS_DEFAULT_PASSWORD"],
     confirm_email: @email_address
   )
 end
@@ -46,8 +46,8 @@ When(/^I complete my application of my local authority as a lower tier waste car
   @front_app.check_details_page.submit
 
   @front_app.sign_up_page.submit(
-    registration_password: ENV["WASTECARRIERSPASSWORD"],
-    confirm_password: ENV["WASTECARRIERSPASSWORD"],
+    registration_password: ENV["WCRS_DEFAULT_PASSWORD"],
+    confirm_password: ENV["WCRS_DEFAULT_PASSWORD"],
     confirm_email: @email_address
   )
 end
@@ -76,8 +76,8 @@ When(/^I complete my application of my partnership as a lower tier waste carrier
   @front_app.check_details_page.submit
 
   @front_app.sign_up_page.submit(
-    registration_password: ENV["WASTECARRIERSPASSWORD"],
-    confirm_password: ENV["WASTECARRIERSPASSWORD"],
+    registration_password: ENV["WCRS_DEFAULT_PASSWORD"],
+    confirm_password: ENV["WCRS_DEFAULT_PASSWORD"],
     confirm_email: @email_address
   )
 end
@@ -105,8 +105,8 @@ When(/^I complete my application of my public body as a lower tier waste carrier
   @front_app.check_details_page.submit
 
   @front_app.sign_up_page.submit(
-    registration_password: ENV["WASTECARRIERSPASSWORD"],
-    confirm_password: ENV["WASTECARRIERSPASSWORD"],
+    registration_password: ENV["WCRS_DEFAULT_PASSWORD"],
+    confirm_password: ENV["WCRS_DEFAULT_PASSWORD"],
     confirm_email: @email_address
   )
 end
@@ -135,8 +135,8 @@ Given(/^I complete my application of a sole trader business as a lower tier wast
   @front_app.check_details_page.submit
 
   @front_app.sign_up_page.submit(
-    registration_password: ENV["WASTECARRIERSPASSWORD"],
-    confirm_password: ENV["WASTECARRIERSPASSWORD"],
+    registration_password: ENV["WCRS_DEFAULT_PASSWORD"],
+    confirm_password: ENV["WCRS_DEFAULT_PASSWORD"],
     confirm_email: @email_address
   )
 end
@@ -165,8 +165,8 @@ Given(/^I complete my application of my limited company "([^"]*)" as a lower tie
   @front_app.check_details_page.submit
 
   @front_app.sign_up_page.submit(
-    registration_password: ENV["WASTECARRIERSPASSWORD"],
-    confirm_password: ENV["WASTECARRIERSPASSWORD"],
+    registration_password: ENV["WCRS_DEFAULT_PASSWORD"],
+    confirm_password: ENV["WCRS_DEFAULT_PASSWORD"],
     confirm_email: @email_address
   )
 end

--- a/features/step_definitions/front_office/new_upper_tier_registration_steps.rb
+++ b/features/step_definitions/front_office/new_upper_tier_registration_steps.rb
@@ -27,8 +27,8 @@ When(/^I complete my aplication of my partnership as a upper tier waste carrier$
   @front_app.relevant_convictions_page.submit(choice: :no)
   @front_app.check_details_page.submit
   @front_app.sign_up_page.submit(
-    registration_password: ENV["WASTECARRIERSPASSWORD"],
-    confirm_password: ENV["WASTECARRIERSPASSWORD"],
+    registration_password: ENV["WCRS_DEFAULT_PASSWORD"],
+    confirm_password: ENV["WCRS_DEFAULT_PASSWORD"],
     confirm_email: @email_address
   )
 end
@@ -59,8 +59,8 @@ When(/^I complete my application of my public body as an upper tier waste carrie
   @front_app.relevant_convictions_page.submit(choice: :no)
   @front_app.check_details_page.submit
   @front_app.sign_up_page.submit(
-    registration_password: ENV["WASTECARRIERSPASSWORD"],
-    confirm_password: ENV["WASTECARRIERSPASSWORD"],
+    registration_password: ENV["WCRS_DEFAULT_PASSWORD"],
+    confirm_password: ENV["WCRS_DEFAULT_PASSWORD"],
     confirm_email: @email_address
   )
 end
@@ -91,8 +91,8 @@ When(/^I complete my application of my sole trader business as a upper tier wast
   @front_app.relevant_convictions_page.submit(choice: :no)
   @front_app.check_details_page.submit
   @front_app.sign_up_page.submit(
-    registration_password: ENV["WASTECARRIERSPASSWORD"],
-    confirm_password: ENV["WASTECARRIERSPASSWORD"],
+    registration_password: ENV["WCRS_DEFAULT_PASSWORD"],
+    confirm_password: ENV["WCRS_DEFAULT_PASSWORD"],
     confirm_email: @email_address
   )
 end

--- a/features/step_definitions/front_office/renewal_steps.rb
+++ b/features/step_definitions/front_office/renewal_steps.rb
@@ -92,7 +92,7 @@ end
 Given(/^I have signed in to renew my registration$/) do
   @renewals_app.waste_carrier_sign_in_page.submit(
     email: Quke::Quke.config.custom["accounts"]["waste_carrier"]["username"],
-    password: ENV["WASTECARRIERSPASSWORD"]
+    password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
 end
 
@@ -101,7 +101,7 @@ Given(/^I have signed in to renew my registration as "([^"]*)"$/) do |username|
   @renewals_app.waste_carrier_sign_in_page.load
   @renewals_app.waste_carrier_sign_in_page.submit(
     email: username,
-    password: ENV["WASTECARRIERSPASSWORD"]
+    password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
 end
 

--- a/features/step_definitions/front_office/upper_tier_edit_charges_steps.rb
+++ b/features/step_definitions/front_office/upper_tier_edit_charges_steps.rb
@@ -4,7 +4,7 @@ Given(/I choose to edit my registration "([^"]*)"$/) do |reg_no|
   @front_app.waste_carrier_sign_in_page.load
   @front_app.waste_carrier_sign_in_page.submit(
     email: Quke::Quke.config.custom["accounts"]["waste_carrier"]["username"],
-    password: ENV["WASTECARRIERSPASSWORD"]
+    password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
   @registration_number = reg_no
 
@@ -104,7 +104,7 @@ Then(/^its previous registration will be "([^"]*)"$/) do |status|
   @back_app.agency_sign_in_page.load
   @back_app.agency_sign_in_page.submit(
     email: Quke::Quke.config.custom["accounts"]["agency_user"]["username"],
-    password: ENV["WASTECARRIERSPASSWORD"]
+    password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
   @back_app.registrations_page.search(search_input: @registration_number)
   expect(@back_app.registrations_page.search_results[0].status.text).to eq(status)

--- a/features/step_definitions/front_office/view_certificate_steps.rb
+++ b/features/step_definitions/front_office/view_certificate_steps.rb
@@ -8,7 +8,7 @@ When(/^I choose to view my certificate for "([^"]*)"$/) do |reg_no|
   @front_app.waste_carrier_sign_in_page.load
   @front_app.waste_carrier_sign_in_page.submit(
     email: Quke::Quke.config.custom["accounts"]["waste_carrier2"]["username"],
-    password: ENV["WASTECARRIERSPASSWORD"]
+    password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
   @registration_number = reg_no
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WC-281

To remove any confusion and help standardise usage of environment variables across Waste Carriers the changes here are to bring the project inline with the other apps, and to help remove duplication where possible.

Specifically we rename the one environment variable used  by this project to follow the standard naming convention for the Waste Carriers Service project.