### PR TITLE
assisted digital tests now pass

### DIFF
--- a/features/back_office/renewals/assisted_digital_renewal.feature
+++ b/features/back_office/renewals/assisted_digital_renewal.feature
@@ -1,4 +1,4 @@
-@backoffice @upper_tier @renewal @broken
+@backoffice @upper_tier @renewal
 
 Feature: Assisted digital renewal of an upper tier public body
   As a carrier of commerical waste
@@ -16,5 +16,6 @@ Scenario: Public body has their upper tier registration renewed by NCCC
 
 Scenario: Limited company has their upper tier registration renewed by NCCC
   Given I choose to renew "CBDU231"
+   And I have signed into the renewals service
    When I renew the limited company registration
    Then the registration will have been renewed

--- a/features/front_office/renewals/renewal_changes.feature
+++ b/features/front_office/renewals/renewal_changes.feature
@@ -15,24 +15,12 @@ Feature: Registered waste carrier chooses to renew their registration from start
         And I have signed in to renew my registration
         But I change my place of business location to "overseas"
        Then I will be able to continue my renewal
-
-   Scenario: Sole trader changes place of business location to Northern Ireland
-      Given I renew my registration using my previous registration number "CBDU208"
-        And I have signed in to renew my registration
-        But I change my place of business location to "northern_ireland"
-       Then I will be notified "You can register in Northern Ireland"
  
   Scenario: Sole trader changes place of business location to Scotland
       Given I renew my registration using my previous registration number "CBDU209"
         And I have signed in to renew my registration
         But I change my place of business location to "scotland"
        Then I will be notified "You can register in Scotland"
-
-  Scenario: Sole trader changes place of business location to Wales
-      Given I renew my registration using my previous registration number "CBDU210"
-        And I have signed in to renew my registration
-        But I change my place of business location to "wales"
-       Then I will be notified "You can register in Wales"
 
     Scenario: On renewal a partnership changes its registration type causing a £40 charge for the change
       Given I renew my registration using my previous registration number "CBDU223"
@@ -48,12 +36,6 @@ Feature: Registered waste carrier chooses to renew their registration from start
 
   Scenario: Partnership changes business type to Limited Liability Partnership
       Given I renew my registration using my previous registration number "CBDU211"
-        And I have signed in to renew my registration
-        But I change the business type to "limitedLiabilityPartnership"
-       Then I will be able to continue my renewal
-
-  Scenario: Limited company changes business type to Limited Liability Partnership
-      Given I renew my registration using my previous registration number "CBDU205"
         And I have signed in to renew my registration
         But I change the business type to "limitedLiabilityPartnership"
        Then I will be able to continue my renewal

--- a/features/front_office/renewals/renewals.feature
+++ b/features/front_office/renewals/renewals.feature
@@ -4,22 +4,10 @@ Feature: Registered waste carrier chooses to renew their registration from regis
   I want to renew my waste carriers licence with the Environment Agency
   So I continue to be compliant with the law
 
-  Scenario: Limited company renews upper tier registration from renewals page
-  	Given I renew my registration using my previous registration number "CBDU215"
-      And I have signed in to renew my registration
-  	 When I complete my limited company renewal steps
-  	 Then I will be notified my renewal is complete
-
   Scenario: Sole trader renews upper tier registration from renewals page
     Given I renew my registration using my previous registration number "CBDU225"
       And I have signed in to renew my registration
      When I complete my sole trader renewal steps
-     Then I will be notified my renewal is complete
-
-  Scenario: Local authority renews upper tier registration from renewals page
-    Given I renew my registration using my previous registration number "CBDU226"
-      And I have signed in to renew my registration
-     When I complete my local authority renewal steps
      Then I will be notified my renewal is complete
  
   Scenario: Limited liability partnership renews upper tier registration from renewals page

--- a/features/page_objects/back_office/registrations/back_office_app.rb
+++ b/features/page_objects/back_office/registrations/back_office_app.rb
@@ -27,6 +27,10 @@ class BackOfficeApp
     @last_page = BusinessTypePage.new
   end
 
+  def carrier_type_page
+    @last_page = CarrierTypePage.new
+  end
+
   def charge_adjustments_page
     @last_page = ChargeAdjustmentsPage.new
   end
@@ -37,6 +41,10 @@ class BackOfficeApp
 
   def confirmation_page
     @last_page = ConfirmationPage.new
+  end
+
+  def confirm_business_type_page
+    @last_page = ConfirmBusinessTypePage.new
   end
 
   def confirm_delete_page
@@ -61,6 +69,10 @@ class BackOfficeApp
 
   def key_people_page
     @last_page = KeyPeoplePage.new
+  end
+
+  def location_page
+    @last_page = LocationPage.new
   end
 
   def new_charge_adjustment_page
@@ -111,12 +123,40 @@ class BackOfficeApp
     @last_page = RegistrationSearchResultsPage.new
   end
 
+  def registration_number_page
+    @last_page = RegistrationNumberPage.new
+  end
+
+  def registration_cards_page
+    @last_page = RegistrationCardsPage.new
+  end
+
+  def renewals_dashboard_page
+    @last_page = RenewalsDashboardPage.new
+  end
+
+  def renewal_information_page
+    @last_page = RenewalInformationPage.new
+  end
+
   def relevant_people_page
     @last_page = RelevantPeoplePage.new
   end
 
   def relevant_convictions_page
     @last_page = RelevantConvictionsPage.new
+  end
+
+  def renewal_received_page
+    @last_page = RenewalReceivedPage.new
+  end
+
+  def renewal_complete_page
+    @last_page = RenewalCompletePage.new
+  end
+
+  def renewal_start_page
+    @last_page = RenewalStartPage.new
   end
 
   def registrations_page
@@ -141,6 +181,10 @@ class BackOfficeApp
 
   def sign_up_page
     @last_page = SignupPage.new
+  end
+
+  def tier_check_page
+    @last_page = TierCheckPage.new
   end
 
   def worldpay_card_choice_page

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -1,4 +1,5 @@
 Given(/^an Environment Agency user has signed in$/) do
+  Capybara.reset_session!
   @back_app = BackOfficeApp.new
   @back_app.agency_sign_in_page.load
   @back_app.agency_sign_in_page.submit(

--- a/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
@@ -8,20 +8,15 @@ Given(/^I have signed into the renewals service$/) do
 end
 
 Given(/^I choose to renew "([^"]*)"$/) do |reg|
-  # renewal_url = Quke::Quke.config.custom["urls"]["back_office_renewals"] + "/bo/renew/#{reg}"
   @registration_number = reg
-  # visit(renewal_url)
-  # @back_renewals_app.agency_sign_in_page.load
   @back_renewals_app.registrations_page.search(search_input: @registration_number)
   @back_renewals_app.registrations_page.search_results[0].renew.click
-  # save registration number for checks later on
-
 end
 # rubocop:disable Metrics/LineLength
 When(/^I renew the local authority registration$/) do
   @back_renewals_app.renewal_start_page.submit
   @back_renewals_app.location_page.submit(choice: :england)
-  @back_renewals_app.confirm_business_type_page.submit(org_type: "Local authority or public body")
+  @back_renewals_app.confirm_business_type_page.submit
   @back_renewals_app.tier_check_page.submit(choice: :skip_check)
   @back_renewals_app.carrier_type_page.submit
   @back_renewals_app.renewal_information_page.submit
@@ -58,7 +53,6 @@ When(/^I renew the local authority registration$/) do
     expiry_month: "12",
     expiry_year: @year
   )
-  @back_renewals_app.worldpay_secure_page.submit
 end
 
 When(/^I renew the limited company registration$/) do
@@ -116,7 +110,6 @@ When(/^I renew the limited company registration$/) do
     expiry_month: "12",
     expiry_year: @year
   )
-  @back_renewals_app.worldpay_secure_page.submit
 end
 
 Given(/^"([^"]*)" has been partially renewed by the account holder$/) do |reg|


### PR DESCRIPTION
Assisted digital renewals now working. Removed unnecessary tests to speed up run time. 