### PR TITLE
Update Travis badge url / delete dependency badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Waste carriers acceptance tests
 
-[![Build Status](https://travis-ci.org/DEFRA/waste-carriers-acceptance-tests.svg?branch=master)](https://travis-ci.org/DEFRA/waste-carriers-acceptance-tests)
+[![Build Status](https://travis-ci.com/DEFRA/waste-carriers-acceptance-tests.svg?branch=master)](https://travis-ci.com/DEFRA/waste-carriers-acceptance-tests)
 [![security](https://hakiri.io/github/DEFRA/waste-carriers-acceptance-tests/master.svg)](https://hakiri.io/github/DEFRA/waste-carriers-acceptance-tests/master)
-[![Dependency Status](https://dependencyci.com/github/DEFRA/waste-carriers-acceptance-tests/badge)](https://dependencyci.com/github/DEFRA/waste-carriers-acceptance-tests)
 
 If your business carries waste then it could require a waste carriers licence
 


### PR DESCRIPTION
The project has been migrated from travis-ci.org to travis-ci.com so updating the url behind the badge to reflect this.

Also deleting the badge for dependency-ci as we no longer integrate with this service.