### PR TITLE
Feature/update tier questions

### DIFF
--- a/features/bo_new/renewals/incomplete_registration_completed_with_assistance.feature
+++ b/features/bo_new/renewals/incomplete_registration_completed_with_assistance.feature
@@ -1,4 +1,4 @@
-@bo_new @upper_tier @bo_renew @renewal @wip
+@bo_new @upper_tier @bo_renew @renewal
 
 Feature: Incomplete renewal of an upper tier public body completed by NCCC
   As a carrier of commerical waste

--- a/features/bo_new/renewals/incomplete_registration_completed_with_assistance.feature
+++ b/features/bo_new/renewals/incomplete_registration_completed_with_assistance.feature
@@ -1,4 +1,4 @@
-@bo_new @upper_tier @bo_renew @renewal
+@bo_new @upper_tier @bo_renew @renewal @wip
 
 Feature: Incomplete renewal of an upper tier public body completed by NCCC
   As a carrier of commerical waste

--- a/features/page_objects/back_office/new/back_office_app.rb
+++ b/features/page_objects/back_office/new/back_office_app.rb
@@ -1,7 +1,6 @@
 # Represents all pages in the back office. Was created to avoid needing to
 # create individual instances of each page throughout the steps.
 # https://github.com/natritmeyer/site_prism#epilogue
-# rubocop:disable Metrics/ClassLength
 class BackOfficeApp
   # Using an attr_reader automatically gives us a my_app.last_page method
   attr_reader :last_page
@@ -45,10 +44,6 @@ class BackOfficeApp
     @last_page = CannotRenewTypeChangePage.new
   end
 
-  def construction_waste_page
-    @last_page = ConstructionWastePage.new
-  end
-
   def dashboard_page
     @last_page = DashboardPage.new
   end
@@ -67,10 +62,6 @@ class BackOfficeApp
 
   def migrate_page
     @last_page = MigratePage.new
-  end
-
-  def other_businesses_page
-    @last_page = OtherBusinessesPage.new
   end
 
   def payments_page
@@ -103,10 +94,6 @@ class BackOfficeApp
 
   def renewal_complete_page
     @last_page = RenewalCompletePage.new
-  end
-
-  def service_provided_page
-    @last_page = ServiceProvidedPage.new
   end
 
   def start_page
@@ -150,4 +137,3 @@ class BackOfficeApp
   end
 
 end
-# rubocop:enable Metrics/ClassLength

--- a/features/page_objects/back_office/new/view_details_page.rb
+++ b/features/page_objects/back_office/new/view_details_page.rb
@@ -17,4 +17,17 @@ class ViewDetailsPage < SitePrism::Page
   element(:renew_link, "a[href*='/ad-privacy-policy/CBD']")
   element(:transfer_link, "a[href*='/transfer-registration']")
 
+  # Sample text on this page:
+  #
+  # Conviction check required
+  # A convictions check is required before this registration can be approved.
+  # Convictions
+  # This registration has matching or declared convictions.
+  # Application rejected
+  # This registration was rejected during a convictions check and cannot be completed.
+  # Convictions
+  # This registration was rejected after a review of the matching or declared convictions.
+  # Payment required
+  # 164 to pay
+
 end

--- a/features/page_objects/front_office/renewals/renewals_app.rb
+++ b/features/page_objects/front_office/renewals/renewals_app.rb
@@ -20,20 +20,12 @@ class RenewalsApp
     @last_page = CannotRenewTypeChangePage.new
   end
 
-  def construction_waste_page
-    @last_page = ConstructionWastePage.new
-  end
-
   def existing_registration_page
     @last_page = ExistingRegistrationPage.new
   end
 
   def location_page
     @last_page = LocationPage.new
-  end
-
-  def other_businesses_page
-    @last_page = OtherBusinessesPage.new
   end
 
   def payment_summary_page
@@ -58,10 +50,6 @@ class RenewalsApp
 
   def renewal_complete_page
     @last_page = RenewalCompletePage.new
-  end
-
-  def service_provided_page
-    @last_page = ServiceProvidedPage.new
   end
 
   def start_page

--- a/features/page_objects/journey/journey_app.rb
+++ b/features/page_objects/journey/journey_app.rb
@@ -69,6 +69,22 @@ class JourneyApp
     @last_page = TierCheckPage.new
   end
 
+  def tier_construction_waste_page
+    @last_page = TierConstructionWastePage.new
+  end
+
+  def tier_farm_only_page
+    @last_page = TierFarmOnlyPage.new
+  end
+
+  def tier_other_businesses_page
+    @last_page = TierOtherBusinessesPage.new
+  end
+
+  def tier_service_provided_page
+    @last_page = TierServiceProvidedPage.new
+  end
+
   def worldpay_payment_page
     @last_page = WorldpayPaymentPage.new
   end

--- a/features/page_objects/journey/tier_check_page.rb
+++ b/features/page_objects/journey/tier_check_page.rb
@@ -1,9 +1,9 @@
 class TierCheckPage < SitePrism::Page
 
   # Do you ever deal with waste from other businesses or households?
+  element(:heading, ".heading-large")
   element(:check_tier, "#tier_check_form_temp_tier_check_yes", visible: false)
   element(:skip_check, "#tier_check_form_temp_tier_check_no", visible: false)
-  element(:heading, ".heading-large")
   element(:submit_button, "input[type='submit']")
 
   def submit(args = {})

--- a/features/page_objects/journey/tier_construction_waste_page.rb
+++ b/features/page_objects/journey/tier_construction_waste_page.rb
@@ -1,9 +1,9 @@
-class ConstructionWastePage < SitePrism::Page
+class TierConstructionWastePage < SitePrism::Page
 
   # Do you ever deal with waste from other businesses or households?
+  element(:heading, ".heading-large")
   element(:yes_construction_waste, "#construction_demolition_form_construction_waste_yes", visible: false)
   element(:no_construction_waste, "#construction_demolition_form_construction_waste_no", visible: false)
-  element(:heading, :xpath, "//h1[contains(text(), 'Do you ever deal')]")
   element(:submit_button, ".button")
 
   def submit(args = {})

--- a/features/page_objects/journey/tier_farm_only_page.rb
+++ b/features/page_objects/journey/tier_farm_only_page.rb
@@ -1,0 +1,19 @@
+class TierFarmOnlyPage < SitePrism::Page
+
+  # Do you ever deal with: Farm or agricultural waste ...?
+  element(:heading, ".heading-large")
+  element(:only_these_types, "#waste_types_form_only_amf_yes", visible: false)
+  element(:other_types, "#waste_types_form_only_amf_no", visible: false)
+  element(:submit_button, ".button")
+
+  def submit(args = {})
+    case args[:choice]
+    when :yes
+      only_these_types.click
+    when :no
+      other_types.click
+    end
+    submit_button.click
+  end
+
+end

--- a/features/page_objects/journey/tier_other_businesses_page.rb
+++ b/features/page_objects/journey/tier_other_businesses_page.rb
@@ -1,9 +1,9 @@
-class OtherBusinessesPage < SitePrism::Page
+class TierOtherBusinessesPage < SitePrism::Page
 
   # Do you ever deal with waste from other businesses or households?
+  element(:heading, ".heading-large")
   element(:yes_other_businesses, "#other_businesses_form_other_businesses_yes", visible: false)
   element(:no_other_businesses, "#other_businesses_form_other_businesses_no", visible: false)
-  element(:heading, :xpath, "//h1[contains(text(), 'Do you ever deal')]")
 
   element(:submit_button, "input[type='submit']")
 

--- a/features/page_objects/journey/tier_service_provided_page.rb
+++ b/features/page_objects/journey/tier_service_provided_page.rb
@@ -1,9 +1,9 @@
-class ServiceProvidedPage < SitePrism::Page
+class TierServiceProvidedPage < SitePrism::Page
 
   # Who produces the waste that you deal with?
+  element(:heading, ".heading-large")
   element(:yes_main_service, "#service_provided_form_is_main_service_yes", visible: false)
   element(:not_main_service, "#service_provided_form_is_main_service_no", visible: false)
-  element(:heading, :xpath, "//h1[contains(text(), 'Who produces the waste that you deal with')]")
   element(:submit_button, ".button")
 
   def submit(args = {})

--- a/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
@@ -114,9 +114,7 @@ When(/^I renew the limited company registration$/) do
   start_internal_renewal
   @journey.confirm_business_type_page.submit
   @journey.tier_check_page.submit(choice: :check_tier)
-  @bo.other_businesses_page.submit(choice: :no)
-  @bo.construction_waste_page.submit(choice: :yes)
-  @journey.carrier_type_page.submit
+  select_upper_tier_options("existing")
   @bo.renewal_information_page.submit
   submit_business_details
   submit_company_people
@@ -271,9 +269,7 @@ Given(/^I renew the limited company registration declaring a conviction and payi
   start_internal_renewal
   @journey.confirm_business_type_page.submit
   @journey.tier_check_page.submit(choice: :check_tier)
-  @bo.other_businesses_page.submit(choice: :no)
-  @bo.construction_waste_page.submit(choice: :yes)
-  @journey.carrier_type_page.submit
+  select_upper_tier_options("existing")
   @bo.renewal_information_page.submit
   submit_business_details
   submit_company_people
@@ -298,6 +294,6 @@ When(/^I approve the conviction check$/) do
   visit((Quke::Quke.config.custom["urls"]["back_office_renewals"]) + "/bo/transient-registrations/#{@registration_number}/convictions")
   # rubocop:enable Metrics/LineLength
 
-  @bo.convictions_page.approve.click
+  @bo.convictions_bo_details_page.approve_button.click
   @bo.convictions_decision_page.submit(conviction_reason: "ok")
 end

--- a/features/step_definitions/front_office/payment_steps.rb
+++ b/features/step_definitions/front_office/payment_steps.rb
@@ -2,10 +2,7 @@ Given(/^I am on the payment page$/) do
   agree_to_renew_in_england
   @journey.confirm_business_type_page.submit
   @journey.tier_check_page.submit(choice: :check_tier)
-  @renewals_app.other_businesses_page.submit(choice: :yes)
-  @renewals_app.service_provided_page.submit(choice: :not_main_service)
-  @renewals_app.construction_waste_page.submit(choice: :yes)
-  @journey.carrier_type_page.submit
+  select_upper_tier_options("existing")
   @renewals_app.renewal_information_page.submit
   submit_business_details
   submit_company_people

--- a/features/step_definitions/front_office/renewal_conviction_check_steps.rb
+++ b/features/step_definitions/front_office/renewal_conviction_check_steps.rb
@@ -2,9 +2,7 @@ When(/^I complete my limited company renewal steps declaring a conviction$/) do
   agree_to_renew_in_england
   @journey.confirm_business_type_page.submit
   @journey.tier_check_page.submit(choice: :check_tier)
-  @renewals_app.other_businesses_page.submit(choice: :no)
-  @renewals_app.construction_waste_page.submit(choice: :yes)
-  @journey.carrier_type_page.submit
+  select_upper_tier_options("existing")
   @renewals_app.renewal_information_page.submit
   submit_business_details
   submit_company_people
@@ -28,9 +26,7 @@ When(/^I complete my limited company renewal steps not declaring a conviction$/)
   agree_to_renew_in_england
   @journey.confirm_business_type_page.submit
   @journey.tier_check_page.submit(choice: :check_tier)
-  @renewals_app.other_businesses_page.submit(choice: :no)
-  @renewals_app.construction_waste_page.submit(choice: :yes)
-  @journey.carrier_type_page.submit
+  select_upper_tier_options("existing")
   @renewals_app.renewal_information_page.submit
   submit_business_details
   people = @journey.company_people_page.dodgy_people
@@ -57,9 +53,7 @@ When(/^I complete my limited company renewal steps not declaring a company convi
   agree_to_renew_in_england
   @journey.confirm_business_type_page.submit
   @journey.tier_check_page.submit(choice: :check_tier)
-  @renewals_app.other_businesses_page.submit(choice: :no)
-  @renewals_app.construction_waste_page.submit(choice: :yes)
-  @journey.carrier_type_page.submit
+  select_upper_tier_options("existing")
   @renewals_app.renewal_information_page.submit
   # Submit the existing company name, as it has a conviction against it:
   submit_limited_company_details("existing")

--- a/features/step_definitions/front_office/renewal_steps.rb
+++ b/features/step_definitions/front_office/renewal_steps.rb
@@ -59,18 +59,15 @@ When(/^I change my carrier broker dealer type to "([^"]*)"$/) do |registration_t
   agree_to_renew_in_england
   @journey.confirm_business_type_page.submit
   @journey.tier_check_page.submit(choice: :check_tier)
-  @renewals_app.other_businesses_page.submit(choice: :yes)
-  @renewals_app.service_provided_page.submit(choice: :not_main_service)
-  @renewals_app.construction_waste_page.submit(choice: :yes)
-  @journey.carrier_type_page.submit(choice: registration_type.to_sym)
+  select_upper_tier_options(registration_type.to_sym)
 end
 
 When(/^I answer questions indicating I should be a lower tier waste carrier$/) do
   agree_to_renew_in_england
   @journey.confirm_business_type_page.submit
   @journey.tier_check_page.submit(choice: :check_tier)
-  @renewals_app.other_businesses_page.submit(choice: :yes)
-  @renewals_app.service_provided_page.submit(choice: :main_service)
+  @journey.tier_other_businesses_page.submit(choice: :yes)
+  @journey.tier_service_provided_page.submit(choice: :main_service)
   @renewals_app.waste_types_page.submit(choice: :yes_only)
 end
 
@@ -107,9 +104,7 @@ When(/^I complete my limited company renewal steps$/) do
   agree_to_renew_in_england
   @journey.confirm_business_type_page.submit
   @journey.tier_check_page.submit(choice: :check_tier)
-  @renewals_app.other_businesses_page.submit(choice: :no)
-  @renewals_app.construction_waste_page.submit(choice: :yes)
-  @journey.carrier_type_page.submit
+  select_upper_tier_options("existing")
   @renewals_app.renewal_information_page.submit
   submit_business_details
   submit_company_people
@@ -150,10 +145,7 @@ When(/^I complete my sole trader renewal steps$/) do
   agree_to_renew_in_england
   @journey.confirm_business_type_page.submit
   @journey.tier_check_page.submit(choice: :check_tier)
-  @renewals_app.other_businesses_page.submit(choice: :yes)
-  @renewals_app.service_provided_page.submit(choice: :not_main_service)
-  @renewals_app.construction_waste_page.submit(choice: :yes)
-  @journey.carrier_type_page.submit
+  select_upper_tier_options("existing")
   @renewals_app.renewal_information_page.submit
   submit_business_details
   people = @journey.company_people_page.main_people
@@ -195,10 +187,7 @@ When(/^I complete my limited liability partnership renewal steps$/) do
   agree_to_renew_in_england
   @journey.confirm_business_type_page.submit
   @journey.tier_check_page.submit(choice: :check_tier)
-  @renewals_app.other_businesses_page.submit(choice: :yes)
-  @renewals_app.service_provided_page.submit(choice: :not_main_service)
-  @renewals_app.construction_waste_page.submit(choice: :yes)
-  @journey.carrier_type_page.submit
+  select_upper_tier_options("existing")
   @renewals_app.renewal_information_page.submit
   submit_business_details
   submit_company_people
@@ -217,10 +206,7 @@ When(/^I complete my limited liability partnership renewal steps choosing to pay
   agree_to_renew_in_england
   @journey.confirm_business_type_page.submit
   @journey.tier_check_page.submit(choice: :check_tier)
-  @renewals_app.other_businesses_page.submit(choice: :yes)
-  @renewals_app.service_provided_page.submit(choice: :not_main_service)
-  @renewals_app.construction_waste_page.submit(choice: :yes)
-  @journey.carrier_type_page.submit
+  select_upper_tier_options("existing")
   @renewals_app.renewal_information_page.submit
   submit_business_details
   submit_company_people
@@ -239,10 +225,7 @@ When(/^I complete my partnership renewal steps$/) do
   agree_to_renew_in_england
   @journey.confirm_business_type_page.submit
   @journey.tier_check_page.submit(choice: :check_tier)
-  @renewals_app.other_businesses_page.submit(choice: :yes)
-  @renewals_app.service_provided_page.submit(choice: :main_service)
-  @renewals_app.waste_types_page.submit(choice: :not_only)
-  @journey.carrier_type_page.submit
+  select_upper_tier_options("existing")
   @renewals_app.renewal_information_page.submit
   submit_business_details
   submit_company_people
@@ -261,10 +244,7 @@ When(/^I add two partners to my renewal$/) do
   agree_to_renew_in_england
   @journey.confirm_business_type_page.submit
   @journey.tier_check_page.submit(choice: :check_tier)
-  @renewals_app.other_businesses_page.submit(choice: :yes)
-  @renewals_app.service_provided_page.submit(choice: :main_service)
-  @renewals_app.waste_types_page.submit(choice: :not_only)
-  @journey.carrier_type_page.submit
+  select_upper_tier_options("existing")
   @renewals_app.renewal_information_page.submit
   submit_business_details
   people = @journey.company_people_page.main_people
@@ -281,9 +261,7 @@ When(/^I complete my overseas company renewal steps$/) do
   @renewals_app.renewal_start_page.submit
   @renewals_app.location_page.submit(choice: :overseas)
   @journey.tier_check_page.submit(choice: :check_tier)
-  @renewals_app.other_businesses_page.submit(choice: :no)
-  @renewals_app.construction_waste_page.submit(choice: :yes)
-  @journey.carrier_type_page.submit
+  select_upper_tier_options("existing")
   @renewals_app.renewal_information_page.submit
   @journey.company_name_page.submit
   @journey.address_manual_page.submit(
@@ -358,10 +336,7 @@ Given(/^I change my companies house number to "([^"]*)"$/) do |number|
   agree_to_renew_in_england
   @journey.confirm_business_type_page.submit
   @journey.tier_check_page.submit(choice: :check_tier)
-  @renewals_app.other_businesses_page.submit(choice: :yes)
-  @renewals_app.service_provided_page.submit(choice: :not_main_service)
-  @renewals_app.construction_waste_page.submit(choice: :yes)
-  @journey.carrier_type_page.submit
+  select_upper_tier_options("existing")
   @renewals_app.renewal_information_page.submit
   @journey.company_number_page.submit(companies_house_number: number.to_sym)
 end

--- a/features/support/journey_helpers.rb
+++ b/features/support/journey_helpers.rb
@@ -30,22 +30,28 @@ def submit_carrier_details(business, tier, carrier)
 end
 
 def old_select_upper_tier_options(carrier)
-  # Carrier can have options:
-  # carrier_broker_dealer, broker_dealer, carrier_dealer
   @back_app.other_businesses_question_page.submit(choice: :no)
   @back_app.construction_waste_question_page.submit(choice: :yes)
   @back_app.registration_type_page.submit(choice: carrier.to_sym)
 end
 
 def select_upper_tier_options(carrier)
-  # Carrier can have options:
-  # carrier_broker_dealer, broker_dealer, carrier_dealer
-
-  # Combine these pages into @journey:
-  @renewals_app.other_businesses_page.submit(choice: :yes)
-  @renewals_app.service_provided_page.submit(choice: :not_main_service)
-  @renewals_app.construction_waste_page.submit(choice: :yes)
-  # Question: are the carrier types the same for old and new apps? If tests pass then delete this comment.
+  # Randomise between 3 ways to achieve an upper tier registration:
+  i = rand(1..3)
+  if i == 1
+    @journey.tier_other_businesses_page.submit(choice: :yes)
+    @journey.tier_service_provided_page.submit(choice: :not_main_service)
+    @journey.tier_construction_waste_page.submit(choice: :yes)
+  elsif i == 2
+    @journey.tier_other_businesses_page.submit(choice: :yes)
+    @journey.tier_service_provided_page.submit(choice: :main_service)
+    @journey.tier_farm_only_page.submit(choice: :no)
+  else
+    @journey.tier_other_businesses_page.submit(choice: :no)
+    @journey.tier_construction_waste_page.submit(choice: :yes)
+  end
+  # Carrier options (same for old and new apps):
+  # carrier_broker_dealer, broker_dealer, carrier_dealer, existing
   @journey.carrier_type_page.submit(choice: carrier.to_sym)
 end
 
@@ -101,7 +107,6 @@ def complete_address
   i = rand(0..2)
   if i.zero?
     # Submit address manually
-    puts "Address type: manual"
     @journey.address_lookup_page.choose_manual_address
     @journey.address_manual_page.submit(
       house_number: "1",
@@ -111,7 +116,6 @@ def complete_address
     )
   else
     # Do a lookup
-    puts "Address type: lookup"
     @journey.address_lookup_page.submit_valid_address
   end
 end


### PR DESCRIPTION
When applying for a renewal, the user has the option to confirm their tier by answering 2-3 questions. There are three possible routes which will end up confirming the application as upper tier.

This change moves those questions into a single helper function, and randomises the route taken. It also gives the tier check page objects more consistent names and moves them to the shared @journey app.

This function will be able to be reused when we move registrations to the new app.