### PR TITLE
Simplify steps to log in to back office

### DIFF
--- a/features/bo_new/dashboard/cease_and_revoke.feature
+++ b/features/bo_new/dashboard/cease_and_revoke.feature
@@ -7,18 +7,16 @@ I need to be able to deregister a registered waste carrier
 So that they no longer have a valid waste carrier licence
 
 Background:
-	Given an Environment Agency user has signed in to the back office
+	Given I sign into the back office as "agency_user_with_payment_refund"
 
   Scenario: Agency user can cease upper tier waste carrier licence
     Given I have a registration "CBDU106"
      When the registration is ceased
-     # Then the registration has a "De-Registered" status
  		 Then the registration has a status of "INACTIVE"
 
   Scenario: Agency user can revoke upper tier waste carrier licence
     Given I have a registration "CBDU111"
      When the registration is revoked
-     # Then the registration has a "Revoked" status
 		 Then the registration has a status of "REVOKED"
 
 		Given an Environment Agency user has signed in to the backend

--- a/features/bo_new/dashboard/transfer.feature
+++ b/features/bo_new/dashboard/transfer.feature
@@ -5,7 +5,7 @@ I need to be able to change the account linked to a registration
 So that users can continue to maintain registrations even if their details change
 
   Scenario: Change the account where user has just one registration
-    Given an Environment Agency user has signed in to the back office
+    Given I sign into the back office as "agency_user"
       And I choose to transfer ownership of "CBDU234" to another user
      When I change the account email to "user@example.com"
      Then I see a confirmation the change has been made

--- a/features/bo_new/renewals/assisted_digital_renewal.feature
+++ b/features/bo_new/renewals/assisted_digital_renewal.feature
@@ -10,19 +10,19 @@ Background:
 
 Scenario: Public body has their upper tier registration renewed by NCCC
   Given I choose to renew "CBDU230"
-    And I have signed into back office as an agency user
+    And I sign into the back office as "agency_user"
    When I renew the local authority registration
    Then the renewal is complete
 
 Scenario: Limited company has their upper tier registration renewed by NCCC
   Given I choose to renew "CBDU231"
-    And I have signed into back office as an agency user
+    And I sign into the back office as "agency_user"
    When I renew the limited company registration
    Then the renewal is complete
 
 Scenario: Expired registration in renewal grace window is only renewed after conviction check and payment is made
   Given I choose to renew "CBDU232"
-    And I have signed into back office as an agency user
+    And I sign into the back office as "agency_user"
     And I renew the limited company registration declaring a conviction and paying by bank transfer
     And I search for "CBDU232" pending payment
    When I mark the renewal payment as received

--- a/features/bo_new/renewals/incomplete_registration_completed_with_assistance.feature
+++ b/features/bo_new/renewals/incomplete_registration_completed_with_assistance.feature
@@ -7,6 +7,6 @@ Feature: Incomplete renewal of an upper tier public body completed by NCCC
 
 Scenario: Public body has their upper tier registration renewed by NCCC
   Given "CBDU229" has been partially renewed by the account holder
-    And I have signed into back office as an agency user
+    And I sign into the back office as "agency_user"
    When I complete the renewal "CBDU229" for the account holder
    Then the renewal is complete

--- a/features/bo_old/dashboard/user_management.feature
+++ b/features/bo_old/dashboard/user_management.feature
@@ -7,6 +7,6 @@ So that these users can then use the renewals service
   Scenario: Creating a agency user in the backend and then migrating the user account to have access to the back office
     Given an Agency super user has signed in to the admin area
       And has created an agency user for "test@example.com"
-     When an Agency super user has signed into the back office
+     When I sign into the back office as "agency_super"
       And migrates the backend users to the back office
      Then the user has been added to the back office

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -8,9 +8,17 @@ Given(/^an Environment Agency user has signed in to the backend$/) do
   )
 end
 
-Given(/^an Environment Agency user has signed in to the back office$/) do
+Given(/^I sign into the back office as "([^"]*)"$/) do |user|
+  # Use this step to sign in to the back office as any of the following users:
+  # agency_user
+  # agency_user_with_payment_refund
+  # finance_admin
+  # finance_basic
+  # waste_carrier
+  # waste_carrier2
+  # agency_super
   load_all_apps
-  sign_in_to_back_office
+  sign_in_to_back_office(user)
 end
 
 Given(/^I am signed in as an Environment Agency user with refunds$/) do
@@ -106,14 +114,14 @@ Then(/^I will be informed by the person taking the call that registration is pen
 end
 
 Then(/^the registration has a status of "([^"]*)"$/) do |status|
-  sign_in_to_back_office
+  sign_in_to_back_office("agency_user")
   @bo.dashboard_page.govuk_banner.home_page.click
   @bo.dashboard_page.submit(search_term: @registration_number)
   expect(@bo.dashboard_page.results_table).to have_text(status)
 end
 
 Then(/^the registration does not have a status of "([^"]*)"$/) do |status|
-  sign_in_to_back_office
+  sign_in_to_back_office("agency_user")
   @bo.dashboard_page.govuk_banner.home_page.click
   @bo.dashboard_page.submit(search_term: @registration_number)
   expect(@bo.dashboard_page.results_table).to have_no_text(status)

--- a/features/step_definitions/back_office/registration_steps.rb
+++ b/features/step_definitions/back_office/registration_steps.rb
@@ -24,7 +24,7 @@ And(/^NCCC finishes the registration$/) do
 end
 
 Then(/^the back office pages show the correct registration details$/) do
-  sign_in_to_back_office
+  sign_in_to_back_office("agency_user")
   check_registration_details(@registration_number)
   info_panel = @bo.view_details_page.info_panel
   page_content = @bo.view_details_page.content

--- a/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
@@ -1,19 +1,3 @@
-Given(/^I have signed into back office as an agency user$/) do
-  @bo = BackOfficeApp.new
-  @journey = JourneyApp.new
-  sign_in_to_back_office
-end
-
-Given(/^I have signed into back office as an agency user with refunds$/) do
-  @bo = BackOfficeApp.new
-  @journey = JourneyApp.new
-  @bo.sign_in_page.load
-  @bo.sign_in_page.submit(
-    email: Quke::Quke.config.custom["accounts"]["agency_user_with_payment_refund"]["username"],
-    password: ENV["WCRS_DEFAULT_PASSWORD"]
-  )
-end
-
 Given(/^there is an existing registration$/) do
   # No action, this just exists to make the feature look nicer
 end
@@ -25,7 +9,7 @@ Given(/^NCCC partially renews an existing registration with "([^"]*)"$/) do |con
   @convictions = convictions
 
   # Search for registration to renew:
-  sign_in_to_back_office
+  sign_in_to_back_office("agency_user")
   @bo.dashboard_page.view_reg_details(search_term: @registration_number)
   @bo.view_details_page.renew_link.click
   start_internal_renewal
@@ -44,7 +28,7 @@ Given(/^NCCC partially renews an existing registration with "([^"]*)"$/) do |con
 end
 
 Given(/^the back office pages show the correct transient renewal details$/) do
-  sign_in_to_back_office
+  sign_in_to_back_office("agency_user")
   @bo.dashboard_page.view_transient_reg_details(search_term: @registration_number)
 
   expect(@bo.view_details_page.heading).to have_text("Renewal " + @registration_number)
@@ -201,14 +185,6 @@ Given(/^has created an agency user for "([^"]*)"$/) do |user|
   @user = user
   expect(@back_app.agency_users_page).to have_text("Agency user was successfully created.")
   @back_app.agency_users_page.sign_out.click
-end
-
-When(/^an Agency super user has signed into the back office$/) do
-  @bo.sign_in_page.load
-  @bo.sign_in_page.submit(
-    email: Quke::Quke.config.custom["accounts"]["agency_super"]["username"],
-    password: ENV["WCRS_DEFAULT_PASSWORD"]
-  )
 end
 
 When(/^migrates the backend users to the back office$/) do

--- a/features/support/conviction_helpers.rb
+++ b/features/support/conviction_helpers.rb
@@ -49,7 +49,7 @@ def reject_flagged_conviction_for_reg(reg, company_name)
 end
 
 def go_to_conviction_dashboard
-  sign_in_to_back_office
+  sign_in_to_back_office("agency_user")
   @bo.dashboard_page.govuk_banner.conviction_checks.click
 end
 

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -8,7 +8,7 @@ def load_all_apps
   @renewals_app = RenewalsApp.new
 end
 
-def sign_in_to_back_office
+def sign_in_to_back_office(user)
   visit((Quke::Quke.config.custom["urls"]["back_office_renewals"]) + "/bo")
   heading = @journey.standard_page.heading.text
 
@@ -16,7 +16,7 @@ def sign_in_to_back_office
   return unless heading == "Sign in"
 
   @bo.sign_in_page.submit(
-    email: Quke::Quke.config.custom["accounts"]["agency_user"]["username"],
+    email: Quke::Quke.config.custom["accounts"][user]["username"],
     password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
 end


### PR DESCRIPTION
This PR combines different steps to log into the back office into a single one, with the user type as a parameter.

Tests and Rubocop pass.