### PR TITLE
Add registration card steps from back office

### DIFF
--- a/.config.yml
+++ b/.config.yml
@@ -18,7 +18,7 @@ app_host: 'http://localhost:3000'
 driver: chrome
 
 # Runs either Chrome or Firefox driver headlessly if set to true
-headless: true
+headless: false
 
 parallel: false
 

--- a/features/bo_new/dashboard/order_cards.feature
+++ b/features/bo_new/dashboard/order_cards.feature
@@ -1,0 +1,20 @@
+@bo_new @upper_tier @bo_dashboard
+Feature: NCCC agent orders registration cards from back office
+  As an NCCC agent
+  I want to order registration cards
+  So that I can help a waste carrier prove they are registered
+
+Background:
+	Given I sign into the back office as "agency_user"
+
+Scenario: NCCC user orders one card by bank card
+  When an agency user orders "1" registration card for "CBDU208"
+   And the agency user pays for the card by bank card
+  Then the card order is confirmed with cleared payment
+   # And the carrier receives an email saying their card order is being printed
+
+Scenario: NCCC user orders 3 cards by bank transfer
+  When an agency user orders "3" registration cards for "CBDU208"
+   And the agency user pays for the card by bank transfer
+  Then the card order is confirmed awaiting payment
+   # And the carrier receives an email saying they need to pay for their card order

--- a/features/fo_new/dashboard/upper_tier_edit_charges.feature
+++ b/features/fo_new/dashboard/upper_tier_edit_charges.feature
@@ -24,7 +24,7 @@ Feature: Upper tier registration edit charges
    When I remove a partner from my registration
    Then I will not be charged for my change
 
-  Scenario: Sole trader changes organsisation type incurring new registration charge
+  Scenario: Sole trader changes organisation type incurring new registration charge
    Given I choose to edit my registration "CBDU103"
     When I change my organisation type to a limited company
      And the charge "£154.00" has been paid

--- a/features/page_objects/back_office/new/view_details_page.rb
+++ b/features/page_objects/back_office/new/view_details_page.rb
@@ -10,15 +10,15 @@ class ViewDetailsPage < SitePrism::Page
   element(:content, ".column-full")
   element(:continue_as_ad_button, ".button", text: "Continue as assisted digital")
 
-  element(:info_panel, ".wcr-panel-border-all")
-  element(:business_name, ".wcr-panel-border-all .heading-medium")
-
   element(:actions_box, ".wcr-actions--push-down")
   element(:renew_link, "a[href*='/ad-privacy-policy/CBD']")
   element(:transfer_link, "a[href*='/transfer']")
-  element(:order_copy_cards_link, "a[href*='/order-copy-cards']")
+  element(:order_cards_link, "a[href*='/order-copy-cards']")
   element(:payment_details_link, "a[href*='/finance_details']")
   element(:cease_or_revoke_link, "a[href*='/cease-or-revoke']")
+
+  element(:info_panel, ".wcr-panel-border-all")
+  element(:business_name, ".wcr-panel-border-all .heading-medium")
 
   # Sample text on this page:
   #

--- a/features/page_objects/front_office/registrations/waste_carrier_registrations_page.rb
+++ b/features/page_objects/front_office/registrations/waste_carrier_registrations_page.rb
@@ -15,8 +15,7 @@ class WasteCarrierRegistrationsPage < SitePrism::Page
     element(:view_certificate, "li:nth-child(1) a")
     element(:edit_registration, "li:nth-child(2) a")
     element(:renew_registration, "li:nth-child(3) a")
-    element(:order_copy_cards, "li:nth-child(4) a")
-    # element(:delete, "li:nth-child(5) a")
+    element(:order_cards_link, "li:nth-child(4) a")
     element(:delete, "[href*='/confirm_delete']")
   end
 

--- a/features/page_objects/journey/cards_confirmation_page.rb
+++ b/features/page_objects/journey/cards_confirmation_page.rb
@@ -1,0 +1,15 @@
+class CardsConfirmationPage < SitePrism::Page
+
+  # Confirmation of order
+
+  element(:error_summary, ".error-summary")
+  element(:heading, ".heading-large")
+
+  element(:confirmation_message, ".flash-success")
+  element(:awaiting_payment_message, ".flash-message")
+  element(:info_table, "table")
+
+  element(:go_to_search_button, "a.button[href$='/bo']")
+  element(:details_for_reg_button, "a.button[href*='/registrations/CBDU']")
+
+end

--- a/features/page_objects/journey/cards_order_page.rb
+++ b/features/page_objects/journey/cards_order_page.rb
@@ -1,0 +1,17 @@
+class CardsOrderPage < SitePrism::Page
+
+  # Order registration cards for CBDU1
+
+  element(:error_summary, ".error-summary")
+  element(:heading, ".heading-large")
+
+  element(:contact_address, ".panel")
+  element(:number_of_cards_form, "#copy_cards_form_temp_cards")
+  element(:submit_button, ".button")
+
+  def submit(args = {})
+    number_of_cards_form.set(args[:number_of_cards]) if args.key?(:number_of_cards)
+    submit_button.click
+  end
+
+end

--- a/features/page_objects/journey/cards_payment_page.rb
+++ b/features/page_objects/journey/cards_payment_page.rb
@@ -1,0 +1,23 @@
+class CardsPaymentPage < SitePrism::Page
+
+  # Payment summary
+
+  element(:error_summary, ".error-summary")
+  element(:heading, ".heading-large")
+
+  element(:cost_table, "table")
+  element(:bank_card_radio, "#copy_cards_payment_form_temp_payment_method_card", visible: false)
+  element(:alternative_payment_radio, "#copy_cards_payment_form_temp_payment_method_bank_transfer", visible: false)
+  element(:submit_button, ".button")
+
+  def submit(args = {})
+    case args[:choice]
+    when :bank_card
+      bank_card_radio.click
+    when :alternative_payment
+      alternative_payment_radio.click
+    end
+    submit_button.click
+  end
+
+end

--- a/features/page_objects/journey/conviction_details_page.rb
+++ b/features/page_objects/journey/conviction_details_page.rb
@@ -14,7 +14,7 @@ class ConvictionDetailsPage < SitePrism::Page
 
   element(:add_person, "input[value='Add another person']")
 
-  elements :remove_person, "a[href*='delete']"
+  elements(:remove_person, "a[href*='delete']")
 
   element(:submit_button, "input[value='Continue']")
 

--- a/features/page_objects/journey/journey_app.rb
+++ b/features/page_objects/journey/journey_app.rb
@@ -13,6 +13,18 @@ class JourneyApp
     @last_page = AddressManualPage.new
   end
 
+  def cards_confirmation_page
+    @last_page = CardsConfirmationPage.new
+  end
+
+  def cards_order_page
+    @last_page = CardsOrderPage.new
+  end
+
+  def cards_payment_page
+    @last_page = CardsPaymentPage.new
+  end
+
   def carrier_type_page
     @last_page = CarrierTypePage.new
   end

--- a/features/page_objects/journey/standard_page.rb
+++ b/features/page_objects/journey/standard_page.rb
@@ -2,11 +2,12 @@
 
 class StandardPage < SitePrism::Page
 
-  # This is a generic page object file used for simple, standard pages, including:
-  #  - footer links (privacy, cookies, accessibility)
+  # This is a generic page object file used for simple, standard pages, to prevent adding lots of separate files
 
   element(:back_link, ".link-back")
+  element(:error_summary, ".error-summary")
   element(:heading, ".heading-large")
   element(:content, "#content")
+  element(:button, ".button")
 
 end

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -206,9 +206,9 @@ end
 And(/^the applicant pays by bank card$/) do
   # On the new app, the payment choice is on a different screen from order copy cards
   if @app == "old"
-    old_order_copy_cards(3)
+    old_order_cards_during_journey(3)
   else
-    order_copy_cards(1)
+    order_cards_during_journey(1)
     @bo.payment_summary_page.submit(choice: :card_payment)
   end
   submit_valid_card_payment

--- a/features/step_definitions/journey/order_cards_steps.rb
+++ b/features/step_definitions/journey/order_cards_steps.rb
@@ -1,0 +1,68 @@
+When(/^an agency user orders "([^"]*)" registration (?:card|cards) for "([^"]*)"$/) do |cards, reg|
+  @registration_number = reg
+  @number_of_cards = cards.to_i
+
+  @bo.dashboard_page.view_reg_details(search_term: reg)
+  @bo.view_details_page.order_cards_link.click
+  expect(@journey.cards_order_page.heading).to have_text("Order registration cards for " + reg)
+
+  # Look for the correct contact address for the seeded data:
+  expect(@journey.cards_order_page.contact_address).to have_text("Richard Fairclough House")
+
+  # Error validation check:
+  @journey.cards_order_page.submit(number_of_cards: "0")
+  expect(@journey.cards_order_page.error_summary).to have_text("enter a number between 1 and 999")
+
+  @journey.cards_order_page.submit(number_of_cards: cards)
+
+  if @number_of_cards == 1
+    expect(@journey.cards_payment_page.cost_table).to have_text("1 registration card total cost")
+  else
+    expect(@journey.cards_payment_page.cost_table).to have_text(cards + " registration cards total cost")
+  end
+  expect(@journey.cards_payment_page.cost_table).to have_text("£" + (@number_of_cards * 5).to_s)
+end
+
+When(/^the agency user pays for the (?:card|cards) by bank card$/) do
+
+  # Error validation check:
+  @journey.cards_payment_page.submit
+  expect(@journey.cards_payment_page.error_summary).to have_text("Select card or alternative payment")
+
+  @journey.cards_payment_page.submit(choice: :bank_card)
+  submit_valid_card_payment
+end
+
+When(/^the agency user pays for the (?:card|cards) by bank transfer$/) do
+  @journey.cards_payment_page.submit(choice: :alternative_payment)
+
+  expect(@journey.standard_page.heading).to have_text("Details for bank transfer")
+  expect(@journey.standard_page.content).to have_text("£" + (@number_of_cards * 5).to_s)
+  expect(@journey.standard_page.content).to have_text("Cards will be sent out after the payment has cleared.")
+  @journey.standard_page.button.click
+end
+
+Then(/^the card order is confirmed with cleared payment$/) do
+  expect(@journey.cards_confirmation_page.confirmation_message).to have_text("Order completed.\nPayment has cleared.")
+  expect(@journey.cards_confirmation_page.info_table).to have_text("£ " + (@number_of_cards * 5).to_s)
+  expect(@journey.cards_confirmation_page.info_table).to have_text(@registration_number)
+
+  @journey.cards_confirmation_page.go_to_search_button.click
+  expect(@bo.dashboard_page.heading).to have_text("Waste carriers registrations")
+end
+
+Then(/^the card order is confirmed awaiting payment$/) do
+  expect(@journey.cards_confirmation_page.awaiting_payment_message).to have_text("Order is awaiting payment.")
+
+  @journey.cards_confirmation_page.details_for_reg_button.click
+  expect(@bo.view_details_page.heading).to have_text("Registration " + @registration_number)
+  expect(@bo.view_details_page.content).to have_text("Payment required")
+end
+
+Then(/^the carrier receives an email saying their card order is being printed$/) do
+  # add steps here when last-email functionality is implemented
+end
+
+Then(/^the carrier receives an email saying they need to pay for their card order$/) do
+  # add steps here when last-email functionality is implemented
+end

--- a/features/support/journey_helpers.rb
+++ b/features/support/journey_helpers.rb
@@ -210,14 +210,15 @@ def check_your_answers
   @journey.declaration_page.submit
 end
 
-def old_order_copy_cards(number_of_cards)
+def old_order_cards_during_journey(number_of_cards)
   @back_app.order_page.submit(
     copy_card_number: number_of_cards,
     choice: :card_payment
   )
 end
 
-def order_copy_cards(number_of_cards)
+def order_cards_during_journey(number_of_cards)
+  # This covers ordering copy cards during a registration or renewal, from the new app
   @bo.registration_cards_page.submit(cards: number_of_cards)
 end
 


### PR DESCRIPTION
This PR adds a test to order registration (copy) cards from the back office app. Previously, we only had tests to order cards as part of the registration/renewal journeys.

It does not yet include email confirmation. Functionality to include last emails has been requested as part of RUBY-850.

I'd appreciate a quick once over in case I can improve on these tests.