### PR TITLE
Fix broken renewal FO tests

### DIFF
--- a/features/fo_new/renewals/renewals_from_user_registrations_page.feature
+++ b/features/fo_new/renewals/renewals_from_user_registrations_page.feature
@@ -12,10 +12,7 @@ Feature: Registered waste carrier chooses to renew their registration from regis
          And view my registration on the dashboard
         Then I will see my registration "CBDU213" has been renewed
 
-  # This test fails because the seeded data puts this registration within the renewal window.
-  # Either the test or the data needs rewriting.
-  # @broken
-  # Scenario: Limited company attempts to renew expired registration
-  # 	   Given I have signed in to view my registrations as "user@example.com"
-  #       When I try to renew anyway by guessing the renewal url for "CBDU233"
-  #       Then I will be told my registration can not be renewed
+  Scenario: Limited company attempts to renew expired registration
+  	   Given I have signed in to view my registrations as "user@example.com"
+        When I try to renew anyway by guessing the renewal url for "CBDU233"
+        Then I will be told my registration can not be renewed

--- a/features/page_objects/front_office/renewals/renewal_complete_page.rb
+++ b/features/page_objects/front_office/renewals/renewal_complete_page.rb
@@ -4,6 +4,6 @@ class RenewalCompletePage < SitePrism::Page
   element(:confirmation_box, ".govuk-box-highlight")
   element(:heading, :xpath, "//h1[contains(text(), 'Renewal complete')]")
 
-  element(:finished, "a[href$='/registrations']")
+  element(:finished, "a[href$='/fo']")
 
 end

--- a/features/step_definitions/front_office/renewal_steps.rb
+++ b/features/step_definitions/front_office/renewal_steps.rb
@@ -359,7 +359,7 @@ end
 When(/^I try to renew anyway by guessing the renewal url for "([^"]*)"$/) do |reg_no|
   @renewals_app = RenewalsApp.new
   @journey = JourneyApp.new
-  renewal_url = Quke::Quke.config.custom["urls"]["front_office_renewals"] + "/fo/renew/#{reg_no}"
+  renewal_url = Quke::Quke.config.custom["urls"]["front_office_renewals"] + "/fo/#{reg_no}/renew"
 
   visit(renewal_url)
 end


### PR DESCRIPTION
@andrewhick highlighted there were a couple of tests that were no longer working when run against the latest version of our code running in our local Vagrant box.

This change covers getting them passing again.
