### PR TITLE
Fix reset dbs rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -165,7 +165,7 @@ def reset_dbs
 
   vagrant_key = File.join(vagrant_loc, "private_key")
   # The following line fully resets the local database and resets the environment without a full vagrant reload:
-  system("ssh -i #{vagrant_key} vagrant@192.168.33.11 'export PATH=\"$HOME/.rbenv/bin:$PATH\" && eval \"$(rbenv init -)\" && cd /vagrant/dbreset && . reset_environment.sh'")
+  system("ssh -i #{vagrant_key} vagrant@192.168.33.11 'export PATH=\"$HOME/.rbenv/bin:$PATH\" && eval \"$(rbenv init -)\" && source /etc/profile.d/myvars.sh && source /vagrant/dbreset/reset_environment.sh'")
 
   current_directory = File.dirname(__FILE__)
   Dir.glob("#{current_directory}/fixtures/*.json").each do |fixture|


### PR DESCRIPTION
The Vagrant box adds the file `/etc/profile.d/myvars.sh` whenever it starts up. This is a bash file of environment variables that should be loaded whenever the box is started using `vagrant up`.

On this basis we assumed when the `reset_dbs` rake task was being run it would see these env vars and so work as if we ran the file whilst ssh'd in using `vagrant ssh`.

Turns out this is not the guess (probably one of those login shell vs non-login shell vs interactive shell things I can never keep on top of).

This changes fixes the issue and ensure the env vars are sourced before we then run any rake tasks in the apps themselves.