### PR TITLE
Add steps to read email following copy card order

### DIFF
--- a/.config.yml
+++ b/.config.yml
@@ -106,6 +106,9 @@ custom:
     back_office_renewals_sign_in: "http://localhost:8001/bo/users/sign_in"
     backend_admin: "http://localhost:3000/admins/sign_in"
     mail_client: "http://localhost:1080"
+    last_email_fe: "http://localhost:3000/email/last-email"
+    last_email_fo: "http://localhost:3002/fo/email/last-email"
+    last_email_bo: "http://localhost:8001/bo/email/last-email"
 
   # # Dev setup
   # urls:
@@ -132,6 +135,9 @@ custom:
   #   back_office_renewals: "https://admin-waste-carriers-tst.aws.defra.cloud/"
   #   back_office_renewals_sign_in: "https://admin-waste-carriers-tst.aws.defra.cloud/bo/users/sign_in"
   #   mail_client: "https://www.mailinator.com"
+  #   last_email_fe: "https://waste-carriers-tst.aws.defra.cloud/email/last-email"
+  #   last_email_fo: "https://waste-carriers-tst.aws.defra.cloud/fo/email/last-email"
+  #   last_email_bo: "https://admin-waste-carriers-tst.aws.defra.cloud/bo/email/last-email"
 
   # # Preprod / staging setup
   # urls:

--- a/features/bo_new/dashboard/order_cards.feature
+++ b/features/bo_new/dashboard/order_cards.feature
@@ -1,4 +1,4 @@
-@bo_new @upper_tier @bo_dashboard @wip
+@bo_new @upper_tier @bo_dashboard
 Feature: NCCC agent orders registration cards from back office
   As an NCCC agent
   I want to order registration cards

--- a/features/bo_new/dashboard/order_cards.feature
+++ b/features/bo_new/dashboard/order_cards.feature
@@ -1,4 +1,4 @@
-@bo_new @upper_tier @bo_dashboard
+@bo_new @upper_tier @bo_dashboard @wip
 Feature: NCCC agent orders registration cards from back office
   As an NCCC agent
   I want to order registration cards

--- a/features/bo_new/dashboard/order_cards.feature
+++ b/features/bo_new/dashboard/order_cards.feature
@@ -11,10 +11,21 @@ Scenario: NCCC user orders one card by bank card
   When an agency user orders "1" registration card for "CBDU208"
    And the agency user pays for the card by bank card
   Then the card order is confirmed with cleared payment
-   # And the carrier receives an email saying their card order is being printed
+   And the registration's balance is 0
+   And the carrier receives an email saying their card order is being printed
 
 Scenario: NCCC user orders 3 cards by bank transfer
   When an agency user orders "3" registration cards for "CBDU208"
-   And the agency user pays for the card by bank transfer
+   And the agency user chooses to pay for the card by bank transfer
   Then the card order is confirmed awaiting payment
-   # And the carrier receives an email saying they need to pay for their card order
+   And the registration has a status of "PAYMENT NEEDED"
+   And the carrier receives an email saying they need to pay for their card order
+   And the registration's balance is 15
+
+  When NCCC makes a payment of 10 by "transfer"
+  Then the registration has a status of "PAYMENT NEEDED"
+   And the registration's balance is 5
+
+  When NCCC pays the remaining balance by "missed_worldpay"
+  Then the registration does not have a status of "PAYMENT NEEDED"
+   And the registration's balance is 0

--- a/features/page_objects/journey/journey_app.rb
+++ b/features/page_objects/journey/journey_app.rb
@@ -73,6 +73,10 @@ class JourneyApp
     @last_page = DeclarationPage.new
   end
 
+  def last_email_page
+    @last_page = LastEmailPage.new
+  end
+
   def standard_page
     @last_page = StandardPage.new
   end

--- a/features/page_objects/journey/last_email_page.rb
+++ b/features/page_objects/journey/last_email_page.rb
@@ -16,7 +16,7 @@ class LastEmailPage < SitePrism::Page
 
   def check_email_for_text(expected_text)
     # Look for an email containing all the strings in the given array
-    # and returns the whole text of the page.
+    # and returns true if all the expected text is present.
 
     10.times do
       page_text = email_content.text

--- a/features/page_objects/journey/last_email_page.rb
+++ b/features/page_objects/journey/last_email_page.rb
@@ -31,13 +31,13 @@ class LastEmailPage < SitePrism::Page
         end
       end
 
-      return "Success" if email_contains_all_text == true
+      return email_contains_all_text if email_contains_all_text == true
 
       page.evaluate_script "window.location.reload()"
     end
 
-    puts "Couldn't find email containing string: " + expected_string
-    "Email not found"
+    puts "Couldn't find email containing text: " + expected_text.to_s
+    email_contains_all_text
   end
 
 end

--- a/features/page_objects/journey/last_email_page.rb
+++ b/features/page_objects/journey/last_email_page.rb
@@ -14,17 +14,28 @@ class LastEmailPage < SitePrism::Page
   # Copy additional functions from WEX tests as needed:
   # https://github.com/DEFRA/waste-exemptions-acceptance-tests/blob/master/features/page_objects/email/last_email_api_page.rb
 
-  def get_page_text(expected_string)
-    # Checks that the page contains a string unique to what's expected
+  def check_email_for_text(expected_text)
+    # Look for an email containing all the strings in the given array
     # and returns the whole text of the page.
 
     10.times do
-      page.evaluate_script "window.location.reload()"
       page_text = email_content.text
-      next unless page_text.include?(expected_string)
 
-      return page_text
+      # Assume email contains all expected text unless proven otherwise:
+      email_contains_all_text = true
+
+      expected_text.each do |element|
+        unless page_text.include?(element)
+          email_contains_all_text = false
+          break
+        end
+      end
+
+      return "Success" if email_contains_all_text == true
+
+      page.evaluate_script "window.location.reload()"
     end
+
     puts "Couldn't find email containing string: " + expected_string
     "Email not found"
   end

--- a/features/page_objects/journey/last_email_page.rb
+++ b/features/page_objects/journey/last_email_page.rb
@@ -31,13 +31,13 @@ class LastEmailPage < SitePrism::Page
         end
       end
 
-      return email_contains_all_text if email_contains_all_text == true
+      return true if email_contains_all_text == true
 
       page.evaluate_script "window.location.reload()"
     end
 
-    puts "Couldn't find email containing text: " + expected_text.to_s
-    email_contains_all_text
+    puts "Couldn't find email containing all text: " + expected_text.to_s
+    false
   end
 
 end

--- a/features/page_objects/journey/last_email_page.rb
+++ b/features/page_objects/journey/last_email_page.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "json"
+
+class LastEmailPage < SitePrism::Page
+  # Page which shows last email sent to any address from the environment.
+  # As there are two app servers, there is a 50% chance that the latest email
+  # will show each time the page is refreshed.
+  # The page will be loaded up to 10 times until the email shows
+  # (a 1 in 1024 chance of the email not showing).
+
+  element(:email_content, "pre")
+
+  # Copy additional functions from WEX tests as needed:
+  # https://github.com/DEFRA/waste-exemptions-acceptance-tests/blob/master/features/page_objects/email/last_email_api_page.rb
+
+  def get_page_text(expected_string)
+    # Checks that the page contains a string unique to what's expected
+    # and returns the whole text of the page.
+
+    10.times do
+      page.evaluate_script "window.location.reload()"
+      page_text = email_content.text
+      next unless page_text.include?(expected_string)
+
+      return page_text
+    end
+    puts "Couldn't find email containing string: " + expected_string
+    "Email not found"
+  end
+
+end

--- a/features/step_definitions/back_office/registration_steps.rb
+++ b/features/step_definitions/back_office/registration_steps.rb
@@ -8,7 +8,7 @@ Given(/^NCCC partially registers an "([^"]*)" tier "([^"]*)" "([^"]*)" with "([^
   @carrier = carrier
   @business = business
   @convictions = convictions
-  @is_transient_renewal = false # May not need this. Delete before next PR if I haven't called it.
+  @is_transient_renewal = false
 
   old_start_internal_registration
   old_submit_carrier_details("limitedCompany", "upper", "carrier_broker_dealer")

--- a/features/step_definitions/journey/order_cards_steps.rb
+++ b/features/step_definitions/journey/order_cards_steps.rb
@@ -64,25 +64,27 @@ end
 Then(/^the carrier receives an email saying their card order is being printed$/) do
   visit(Quke::Quke.config.custom["urls"]["last_email_bo"])
 
-  # Get the text of the last email containing the chosen text.
-  # Take care that this test does not pick up an email from a previous test run.
-  # This test could fail if a similar copy card order has been placed recently.
-  email_text = @journey.last_email_page.get_page_text("We’re printing your waste carriers registration card")
+  text_to_check = [
+    "We’re printing your waste carriers registration card",
+    @registration_number,
+    "Order: " + @number_of_cards.to_s + " registration card",
+    "Paid: £" + (@number_of_cards.to_i * 5).to_s + " by debit or credit card"
+  ]
 
-  # Validate the email text against what's expected:
-  expect(email_text).to include(@registration_number)
-  expect(email_text).to include("Order: " + @number_of_cards.to_s + " registration card")
-  expect(email_text).to include("Paid: £" + (@number_of_cards.to_i * 5).to_s + " by debit or credit card")
+  # Check there is an email containing all required strings:
+  expect(@journey.last_email_page.check_email_for_text(text_to_check)).to eq("Success")
 end
 
 Then(/^the carrier receives an email saying they need to pay for their card order$/) do
   visit(Quke::Quke.config.custom["urls"]["last_email_bo"])
 
-  # Get the text of the last email containing the chosen text:
-  email_text = @journey.last_email_page.get_page_text("You need to pay for your waste carriers registration card")
+  text_to_check = [
+    "You need to pay for your waste carriers registration card",
+    @registration_number,
+    "We cannot print the cards until we receive confirmation that you have paid",
+    "You ordered " + @number_of_cards.to_s + " registration card"
+  ]
 
-  # Validate the email text against what's expected:
-  expect(email_text).to include(@registration_number)
-  expect(email_text).to include("We cannot print the cards until we receive confirmation that you have paid")
-  expect(email_text).to include("You ordered " + @number_of_cards.to_s + " registration card")
+  # Check there is an email containing all required strings:
+  expect(@journey.last_email_page.check_email_for_text(text_to_check)).to eq("Success")
 end

--- a/features/step_definitions/journey/order_cards_steps.rb
+++ b/features/step_definitions/journey/order_cards_steps.rb
@@ -71,7 +71,7 @@ Then(/^the carrier receives an email saying their card order is being printed$/)
 
   # Check there is an email containing all strings in text_to_check:
   visit(Quke::Quke.config.custom["urls"]["last_email_bo"])
-  expect(@journey.last_email_page.check_email_for_text(text_to_check))
+  expect(@journey.last_email_page.check_email_for_text(text_to_check)).to be true
 end
 
 Then(/^the carrier receives an email saying they need to pay for their card order$/) do
@@ -84,5 +84,5 @@ Then(/^the carrier receives an email saying they need to pay for their card orde
 
   # Check there is an email containing all strings in text_to_check:
   visit(Quke::Quke.config.custom["urls"]["last_email_bo"])
-  expect(@journey.last_email_page.check_email_for_text(text_to_check))
+  expect(@journey.last_email_page.check_email_for_text(text_to_check)).to be true
 end

--- a/features/step_definitions/journey/order_cards_steps.rb
+++ b/features/step_definitions/journey/order_cards_steps.rb
@@ -62,8 +62,6 @@ Then(/^the card order is confirmed awaiting payment$/) do
 end
 
 Then(/^the carrier receives an email saying their card order is being printed$/) do
-  visit(Quke::Quke.config.custom["urls"]["last_email_bo"])
-
   text_to_check = [
     "We’re printing your waste carriers registration card",
     @registration_number,
@@ -71,13 +69,12 @@ Then(/^the carrier receives an email saying their card order is being printed$/)
     "Paid: £" + (@number_of_cards.to_i * 5).to_s + " by debit or credit card"
   ]
 
-  # Check there is an email containing all required strings:
-  expect(@journey.last_email_page.check_email_for_text(text_to_check)).to eq("Success")
+  # Check there is an email containing all strings in text_to_check:
+  visit(Quke::Quke.config.custom["urls"]["last_email_bo"])
+  expect(@journey.last_email_page.check_email_for_text(text_to_check))
 end
 
 Then(/^the carrier receives an email saying they need to pay for their card order$/) do
-  visit(Quke::Quke.config.custom["urls"]["last_email_bo"])
-
   text_to_check = [
     "You need to pay for your waste carriers registration card",
     @registration_number,
@@ -85,6 +82,7 @@ Then(/^the carrier receives an email saying they need to pay for their card orde
     "You ordered " + @number_of_cards.to_s + " registration card"
   ]
 
-  # Check there is an email containing all required strings:
-  expect(@journey.last_email_page.check_email_for_text(text_to_check)).to eq("Success")
+  # Check there is an email containing all strings in text_to_check:
+  visit(Quke::Quke.config.custom["urls"]["last_email_bo"])
+  expect(@journey.last_email_page.check_email_for_text(text_to_check))
 end


### PR DESCRIPTION
These tests now check the email content when registration cards are ordered from the back office. It is the first Waste Carriers test to use the new `/email/last-email` path, to view the latest email sent by the service.

The feature also adds tests under the new payments functionality to copy cards.

The check currently reads the whole email JSON without parsing it, but I intend to reuse the parsing from WEX in future email tests.

New tests and rubocop pass.