### PR TITLE
Add finance admin steps

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,11 @@ Metrics/BlockLength:
   Exclude:
     - "features/step_definitions/**/*"
 
+Layout/LineLength:
+  Exclude:
+    - "features/step_definitions/**/*"
+    - "features/support/**/*"
+
 # With Cucumber everything gets loaded into the 'world' from the start so there
 # is no single point of entry where we can instantiate and control state that
 # that needs to be shared. One of the ways this manifests is with helper

--- a/features/bo_new/dashboard/order_cards.feature
+++ b/features/bo_new/dashboard/order_cards.feature
@@ -22,7 +22,11 @@ Scenario: NCCC user orders 3 cards by bank transfer
    And the carrier receives an email saying they need to pay for their card order
    And the registration's balance is 15
 
-  When NCCC makes a payment of 10 by "transfer"
+  When NCCC makes a payment of 5 by "transfer"
+  Then the registration has a status of "PAYMENT NEEDED"
+   And the registration's balance is 10
+
+  When NCCC makes a payment of 5 by "postal"
   Then the registration has a status of "PAYMENT NEEDED"
    And the registration's balance is 5
 

--- a/features/bo_new/finance/finance_admin.feature
+++ b/features/bo_new/finance/finance_admin.feature
@@ -1,0 +1,76 @@
+@bo_new @upper_tier @finance
+
+Feature: Finance admin
+  As a user with finance privilieges
+  I want to administer finances for a registration
+  So that the user and the EA have the correct amount of money
+
+  This feature covers all main finance admin operations: refunds and charge adjustments (frequent)
+  plus reversals and writeoffs (less frequent).
+
+  Background:
+      Given an Environment Agency user has signed in to the backend
+        And NCCC partially registers an upper tier "broker_dealer" "soleTrader" with "no convictions"
+
+  Scenario: [RUBY-811] Refund WorldPay payments on registration and renewal
+      Given the applicant pays by bank card
+        And NCCC finishes the registration
+
+      Given the registration's balance is 0
+        And NCCC makes a payment of 42 by "cheque"
+       When an agency-refund-payment-user refunds the WorldPay payment
+       Then the WorldPay payment is shown as refunded
+        And the registration's balance is 0
+
+      Given NCCC partially renews an existing registration with "no convictions"
+        And the applicant pays by bank card
+        And the registration's balance is 0
+
+      Given NCCC makes a payment of 99 by "cheque"
+       When an agency-refund-payment-user refunds the WorldPay payment
+       Then the WorldPay payment is shown as refunded
+        And the registration's balance is 0
+
+  Scenario: [RUBY-870] Adjust charges on registration and renewal
+      Given the applicant chooses to pay for the registration by bank transfer ordering 1 copy card
+        And NCCC makes a payment of 154 by "cash"
+        And the registration has a status of "IN PROGRESS"
+
+      Given the registration's balance is 5
+       When a finance admin user adjusts the charge by -5
+        And the registration has a status of "ACTIVE"
+        And the registration does not have a status of "PAYMENT NEEDED"
+
+      Given the registration's balance is 0
+       When a finance admin user adjusts the charge by 10
+       Then the registration's balance is 10
+        And the registration has a status of "PAYMENT NEEDED"
+        And NCCC makes a payment of 10 by "cash"
+
+      Given NCCC partially renews an existing registration with "no convictions"
+        And the applicant chooses to pay for the renewal by bank transfer ordering 2 copy cards
+        And NCCC makes a payment of 105 by "cash"
+        And the transient renewal's balance is 10
+       When a finance admin user adjusts the charge by -15
+       Then the registration's balance is -5
+        And the registration has a status of "ACTIVE"
+
+  Scenario: [RUBY-809 & 810] Reverse and write off
+      Given the applicant chooses to pay for the registration by bank transfer ordering 1 copy card
+        And NCCC makes a payment of 154 by "cash"
+        And NCCC makes a payment of 10 by "cheque"
+
+      Given the registration's balance is -5
+       When an "agency_user_with_payment_refund" reverses the previous payment
+       Then the registration has a status of "ACTIVE"
+        And the registration has a status of "PAYMENT NEEDED"
+
+      Given the registration's balance is 5
+       When an "agency_user_with_payment_refund" writes off the outstanding balance
+       Then the registration's balance is 0
+        And the registration does not have a status of "PAYMENT NEEDED"
+
+      Given a finance admin user adjusts the charge by 6
+       When a "finance_admin" writes off the outstanding balance
+       Then the registration's balance is 0
+        And the registration does not have a status of "PAYMENT NEEDED"

--- a/features/bo_new/finance/registration_payments.feature
+++ b/features/bo_new/finance/registration_payments.feature
@@ -8,7 +8,7 @@ Feature: [RUBY-826] Pay for registrations
   Background:
       Given an Environment Agency user has signed in to the backend
         And NCCC partially registers an upper tier "broker_dealer" "soleTrader" with "no convictions"
-        And the applicant chooses to pay by bank transfer ordering 1 copy card
+        And the applicant chooses to pay for the registration by bank transfer ordering 1 copy card
         And I sign into the back office as "agency_user"
         And the registration's balance is 159
 
@@ -36,5 +36,4 @@ Feature: [RUBY-826] Pay for registrations
         And the back office pages show the correct registration details
         And the registration's balance is 0
 
-# Next: pay for copy cards, partly by postal order, complete by bank transfer
-# Then: pay for a registration with convictions (adapt from bo_old/upper_ad_convictions_registrations)
+# To add: pay for a registration with convictions (adapt from bo_old/upper_ad_convictions_registrations)

--- a/features/bo_new/finance/renewal_payments.feature
+++ b/features/bo_new/finance/renewal_payments.feature
@@ -1,4 +1,4 @@
-@bo_new @upper_tier @bo_renew @renewal
+@bo_new @upper_tier @finance
 Feature: Recording of a non worldpay renewal payment and negative conviction check marks the registration renewal as completed.
   As an administrator of the Waste Carriers service
   I need to be able to record payments and conviction check results

--- a/features/bo_old/registrations/upper_ad_ltd_registration.feature
+++ b/features/bo_old/registrations/upper_ad_ltd_registration.feature
@@ -16,5 +16,5 @@ Feature: Assisted digital registration of an upper tier Limited company
 
 @smoke
   Scenario: NCCC successfully registers a limited company for a upper tier waste carriers licence choosing to pay by bank transfer
-    When the applicant chooses to pay by bank transfer ordering 4 copy cards
+    When the applicant chooses to pay for the registration by bank transfer ordering 4 copy cards
     Then the registration status will be "Awaiting payment"

--- a/features/bo_old/registrations/upper_ad_partnership_registration.feature
+++ b/features/bo_old/registrations/upper_ad_partnership_registration.feature
@@ -16,5 +16,5 @@ Feature: Assisted digital registration of an upper tier partnership
 
 @smoke
   Scenario: NCCC successfully registers a partnership for a upper tier waste carriers licence choosing to pay by bank transfer
-    When the applicant chooses to pay by bank transfer ordering 1 copy card
+    When the applicant chooses to pay for the registration by bank transfer ordering 1 copy card
    	Then the registration status will be "Awaiting payment"

--- a/features/bo_old/registrations/upper_ad_public_body_registration.feature
+++ b/features/bo_old/registrations/upper_ad_public_body_registration.feature
@@ -16,5 +16,5 @@ Feature: Assisted digital registration of an upper tier public body
 
 @smoke
   Scenario: NCCC successfully registers a public body for a upper tier waste carriers licence choosing to pay by bank transfer
-    When the applicant chooses to pay by bank transfer ordering 3 copy cards
+    When the applicant chooses to pay for the registration by bank transfer ordering 3 copy cards
    	Then the registration status will be "Awaiting payment"

--- a/features/bo_old/registrations/upper_ad_sole_trader_registration.feature
+++ b/features/bo_old/registrations/upper_ad_sole_trader_registration.feature
@@ -16,5 +16,5 @@ Feature: Assisted digital registration of an upper tier sole trader
 
 @smoke
   Scenario: NCCC successfully registers a sole trader for a upper tier waste carriers licence choosing to pay by bank transfer
-    When the applicant chooses to pay by bank transfer ordering 3 copy cards
+    When the applicant chooses to pay for the registration by bank transfer ordering 3 copy cards
     Then the registration status will be "Awaiting payment"

--- a/features/page_objects/back_office/new/back_office_app.rb
+++ b/features/page_objects/back_office/new/back_office_app.rb
@@ -2,6 +2,7 @@
 # create individual instances of each page throughout the steps.
 # https://github.com/natritmeyer/site_prism#epilogue
 
+# rubocop:disable Metrics/ClassLength
 class BackOfficeApp
   # Using an attr_reader automatically gives us a my_app.last_page method
   attr_reader :last_page
@@ -53,6 +54,14 @@ class BackOfficeApp
     @last_page = ExistingRegistrationPage.new
   end
 
+  def finance_charge_adjust_input_page
+    @last_page = FinanceChargeAdjustInputPage.new
+  end
+
+  def finance_charge_adjust_select_page
+    @last_page = FinanceChargeAdjustSelectPage.new
+  end
+
   def finance_payment_details_page
     @last_page = FinancePaymentDetailsPage.new
   end
@@ -63,6 +72,22 @@ class BackOfficeApp
 
   def finance_payment_method_page
     @last_page = FinancePaymentMethodPage.new
+  end
+
+  def finance_refund_select_page
+    @last_page = FinanceRefundSelectPage.new
+  end
+
+  def finance_reversal_input_page
+    @last_page = FinanceReversalInputPage.new
+  end
+
+  def finance_reversal_select_page
+    @last_page = FinanceReversalSelectPage.new
+  end
+
+  def finance_writeoff_page
+    @last_page = FinanceWriteoffPage.new
   end
 
   def finish_assisted_page
@@ -138,3 +163,4 @@ class BackOfficeApp
   end
 
 end
+# rubocop:enable Metrics/ClassLength

--- a/features/page_objects/back_office/new/finance_charge_adjust_input_page.rb
+++ b/features/page_objects/back_office/new/finance_charge_adjust_input_page.rb
@@ -1,0 +1,27 @@
+require_relative "sections/govuk_banner.rb"
+
+class FinanceChargeAdjustInputPage < SitePrism::Page
+
+  # Positive/Negative charge adjustment (debit) for CBDU1
+
+  section(:govuk_banner, GovukBanner, GovukBanner::SELECTOR)
+
+  element(:back_link, ".link-back")
+  element(:heading, ".heading-large")
+  element(:content, "#content")
+
+  element(:amount_form, "input[id*='charge_adjust_form_amount']")
+  element(:reference_form, "input[id*='charge_adjust_form_reference']")
+  element(:reason_form, "textarea[id*='charge_adjust_form_description']")
+
+  element(:submit_button, "input[type='submit']")
+
+  def submit(args = {})
+    amount_form.set(args[:amount]) if args.key?(:amount)
+    reference_form.set(args[:reference]) if args.key?(:reference)
+    reason_form.set(args[:reason]) if args.key?(:reason)
+
+    submit_button.click
+  end
+
+end

--- a/features/page_objects/back_office/new/finance_charge_adjust_select_page.rb
+++ b/features/page_objects/back_office/new/finance_charge_adjust_select_page.rb
@@ -1,0 +1,28 @@
+require_relative "sections/govuk_banner.rb"
+
+class FinanceChargeAdjustSelectPage < SitePrism::Page
+
+  # Make a charge adjustment for CBDU1
+
+  section(:govuk_banner, GovukBanner, GovukBanner::SELECTOR)
+
+  element(:back_link, ".link-back")
+  element(:heading, ".heading-large")
+  element(:content, "#content")
+
+  element(:positive_radio, "#charge_adjust_form_charge_type_positive", visible: false)
+  element(:negative_radio, "#charge_adjust_form_charge_type_negative", visible: false)
+
+  element(:submit_button, "input[type='submit']")
+
+  def submit(args = {})
+    case args[:choice]
+    when :positive
+      positive_radio.click
+    when :negative
+      negative_radio.click
+    end
+    submit_button.click
+  end
+
+end

--- a/features/page_objects/back_office/new/finance_refund_select_page.rb
+++ b/features/page_objects/back_office/new/finance_refund_select_page.rb
@@ -1,0 +1,13 @@
+class FinanceRefundSelectPage < SitePrism::Page
+
+  # Which payment do you want to refund?
+
+  section(:govuk_banner, GovukBanner, GovukBanner::SELECTOR)
+
+  element(:back_link, ".link-back")
+  element(:heading, ".heading-large")
+  element(:content, "#content")
+
+  elements(:refund_links, "a[href*='/refunds/']")
+
+end

--- a/features/page_objects/back_office/new/finance_reversal_input_page.rb
+++ b/features/page_objects/back_office/new/finance_reversal_input_page.rb
@@ -1,0 +1,16 @@
+require_relative "sections/govuk_banner.rb"
+
+class FinanceReversalInputPage < SitePrism::Page
+
+  section(:govuk_banner, GovukBanner, GovukBanner::SELECTOR)
+  element(:heading, ".heading-large")
+
+  element(:reason_form, "#reversal_form_reason")
+  element(:submit_button, ".button")
+
+  def submit(args = {})
+    reason_form.set(args[:reason]) if args.key?(:reason)
+    submit_button.click
+  end
+
+end

--- a/features/page_objects/back_office/new/finance_reversal_select_page.rb
+++ b/features/page_objects/back_office/new/finance_reversal_select_page.rb
@@ -1,0 +1,13 @@
+class FinanceReversalSelectPage < SitePrism::Page
+
+  # Which payment do you want to reverse?
+
+  section(:govuk_banner, GovukBanner, GovukBanner::SELECTOR)
+
+  element(:back_link, ".link-back")
+  element(:heading, ".heading-large")
+  element(:content, "#content")
+
+  elements(:reverse_links, "a[href*='/reversals/']")
+
+end

--- a/features/page_objects/back_office/new/finance_writeoff_page.rb
+++ b/features/page_objects/back_office/new/finance_writeoff_page.rb
@@ -1,0 +1,16 @@
+require_relative "sections/govuk_banner.rb"
+
+class FinanceWriteoffPage < SitePrism::Page
+
+  section(:govuk_banner, GovukBanner, GovukBanner::SELECTOR)
+  element(:heading, ".heading-large")
+
+  element(:reason_form, "#write_off_form_comment")
+  element(:submit_button, ".button")
+
+  def submit(args = {})
+    reason_form.set(args[:reason]) if args.key?(:reason)
+    submit_button.click
+  end
+
+end

--- a/features/step_definitions/back_office/registration_steps.rb
+++ b/features/step_definitions/back_office/registration_steps.rb
@@ -22,7 +22,7 @@ Given(/^NCCC partially registers an upper tier "([^"]*)" "([^"]*)" with "([^"]*)
 end
 
 And(/^NCCC finishes the registration$/) do
-  @registration_number = old_complete_registration_from_bo(@business, @tier, @carrier)
+  @reg_number = old_complete_registration_from_bo(@business, @tier, @carrier)
 end
 
 Given(/^NCCC registers a lower tier "([^"]*)"$/) do |business|
@@ -39,12 +39,12 @@ Given(/^NCCC registers a lower tier "([^"]*)"$/) do |business|
   old_submit_business_details(@business_name, @tier)
   old_submit_contact_details_from_bo
   old_check_your_answers
-  @registration_number = old_complete_registration_from_bo(@business, @tier, @carrier)
+  @reg_number = old_complete_registration_from_bo(@business, @tier, @carrier)
 end
 
 Then(/^the back office pages show the correct registration details$/) do
   sign_in_to_back_office("agency_user")
-  check_registration_details(@registration_number)
+  check_registration_details(@reg_number)
   info_panel = @bo.registration_details_page.info_panel
   page_content = @bo.registration_details_page.content
   expect(@bo.registration_details_page.business_name).to have_text(@business_name)
@@ -82,7 +82,7 @@ Then(/^the certificate shows the correct details$/) do
   expect(@bo.registration_certificate_page.heading).to have_text("Certificate of Registration")
   page_content = @bo.registration_certificate_page.content
   expect(page_content).to have_text(@business_name)
-  expect(page_content).to have_text(@registration_number)
+  expect(page_content).to have_text(@reg_number)
   expect(@bo.registration_certificate_page.certificate_dates_are_correct(@tier, @is_renewal)).to be true
   if @tier == "upper"
     expect(page_content).to have_text("Your registration will last 3 years")

--- a/features/step_definitions/back_office/transfer_steps.rb
+++ b/features/step_definitions/back_office/transfer_steps.rb
@@ -1,5 +1,5 @@
 Given(/^I choose to transfer ownership of "([^"]*)" to another user$/) do |reg|
-  @registration_number = reg
+  @reg_number = reg
   @bo.dashboard_page.view_reg_details(search_term: reg)
   @bo.registration_details_page.transfer_link.click
 end

--- a/features/step_definitions/back_office/upper_tier/application_refund_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/application_refund_steps.rb
@@ -37,28 +37,28 @@ Given(/^I have an application paid by credit card$/) do
 
   submit_valid_card_payment
 
-  @registration_number = @back_app.finish_assisted_page.registration_number.text
+  @reg_number = @back_app.finish_assisted_page.registration_number.text
   @back_app.agency_sign_in_page.load
   @back_app.registrations_page.sign_out.click
 end
 
 When(/^I reverse the application payment$/) do
-  @back_app.registrations_page.search(search_input: @registration_number)
+  @back_app.registrations_page.search(search_input: @reg_number)
   @back_app.registrations_page.search_results[0].payment_status.click
   @payment_amount = @back_app.payment_status_page.payment_history_amount.text
-  expect(@back_app.payment_reversals_page).to have_text(@registration_number)
+  expect(@back_app.payment_reversals_page).to have_text(@reg_number)
   @back_app.payment_status_page.reversals.click
   @back_app.payment_reversals_page.select_payment.click
-  @back_app.new_reversal_page.submit(payment_comment: "Reversal for " + @registration_number)
+  @back_app.new_reversal_page.submit(payment_comment: "Reversal for " + @reg_number)
 end
 
 When(/^I select the application to refund$/) do
-  @back_app.registrations_page.search(search_input: @registration_number)
+  @back_app.registrations_page.search(search_input: @reg_number)
   @back_app.registrations_page.search_results[0].payment_status.click
 end
 
 When(/^I refund the worldpay payment$/) do
-  @back_app.registrations_page.search(search_input: @registration_number)
+  @back_app.registrations_page.search(search_input: @reg_number)
   @back_app.registrations_page.search_results[0].payment_status.click
   @payment_amount = @back_app.payment_status_page.payment_history_amount.text
   @back_app.payment_status_page.refund.click
@@ -81,7 +81,7 @@ Then(/^the application payment will be reversed$/) do
 end
 
 Then(/^the reversal will be shown in the payment history$/) do
-  expect(@back_app.payment_status_page).to have_text("Reversal for " + @registration_number)
+  expect(@back_app.payment_status_page).to have_text("Reversal for " + @reg_number)
 end
 
 Then(/^the outstanding balance will be the amount previously paid$/) do

--- a/features/step_definitions/back_office/upper_tier/assisted_digital_new_upper_tier_registration_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/assisted_digital_new_upper_tier_registration_steps.rb
@@ -99,7 +99,7 @@ When(/^I have my public body upper tier waste carrier application completed for 
   @back_app.relevant_convictions_page.submit(choice: :no)
   @back_app.check_details_page.submit
 end
-# rubocop:disable Layout/LineLength
+
 Given(/^a limited company with companies house number "([^"]*)" is registered as an upper tier waste carrier$/) do |ch_no|
 
   # Store company name and number for later tests:
@@ -141,10 +141,9 @@ Given(/^a limited company with companies house number "([^"]*)" is registered as
 
   submit_valid_card_payment
 
-  @registration_number = @back_app.finish_assisted_page.registration_number.text
-  puts "Registration " + @registration_number + " completed with conviction match on company number"
+  @reg_number = @back_app.finish_assisted_page.registration_number.text
+  puts "Registration " + @reg_number + " completed with conviction match on company number"
 end
-# rubocop:enable Layout/LineLength
 
 Given(/^(?:a|my) limited company "([^"]*)" registers as an upper tier waste carrier$/) do |co_name|
   @company_name = co_name
@@ -182,7 +181,7 @@ Given(/^(?:a|my) limited company "([^"]*)" registers as an upper tier waste carr
 
   submit_valid_card_payment
 
-  @registration_number = @back_app.finish_assisted_page.registration_number.text
+  @reg_number = @back_app.finish_assisted_page.registration_number.text
   @back_app.agency_sign_in_page.load
 end
 
@@ -219,7 +218,7 @@ Given(/a key person with a conviction registers as a sole trader upper tier wast
 
   submit_valid_card_payment
 
-  @registration_number = @back_app.finish_assisted_page.registration_number.text
+  @reg_number = @back_app.finish_assisted_page.registration_number.text
 end
 
 Given(/^a conviction is declared when registering their partnership for an upper tier waste carrier$/) do
@@ -259,5 +258,5 @@ Given(/^a conviction is declared when registering their partnership for an upper
 
   submit_valid_card_payment
 
-  @registration_number = @back_app.finish_assisted_page.registration_number.text
+  @reg_number = @back_app.finish_assisted_page.registration_number.text
 end

--- a/features/step_definitions/back_office/upper_tier/charge_adjustment_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/charge_adjustment_steps.rb
@@ -1,5 +1,5 @@
 When(/^I add a positive charge of £(\d+) to the registration$/) do |charge|
-  @back_app.registrations_page.search(search_input: @registration_number)
+  @back_app.registrations_page.search(search_input: @reg_number)
   @back_app.registrations_page.search_results[0].payment_status.click
   @back_app.payment_status_page.charge_adjustments.click
   @back_app.charge_adjustments_page.add_charge.click
@@ -11,7 +11,7 @@ When(/^I add a positive charge of £(\d+) to the registration$/) do |charge|
 end
 
 When(/^I add a negative charge of £(\d+) to the registration$/) do |charge|
-  @back_app.registrations_page.search(search_input: @registration_number)
+  @back_app.registrations_page.search(search_input: @reg_number)
   @back_app.registrations_page.search_results[0].payment_status.click
   @back_app.payment_status_page.charge_adjustments.click
   @back_app.charge_adjustments_page.add_negative_charge.click

--- a/features/step_definitions/back_office/upper_tier/conviction_checks_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/conviction_checks_steps.rb
@@ -1,15 +1,15 @@
 When(/^the conviction check is immediately approved by an agency user$/) do
-  approve_conviction_immediately_for_reg(@registration_number, @company_name)
+  approve_conviction_immediately_for_reg(@reg_number, @company_name)
 end
 
 When(/^the conviction check is flagged by an agency user$/) do
-  flag_conviction_for_reg(@registration_number, @company_name)
+  flag_conviction_for_reg(@reg_number, @company_name)
 end
 
 When(/^the flagged conviction is approved by an agency user$/) do
-  approve_flagged_conviction_for_reg(@registration_number, @company_name)
+  approve_flagged_conviction_for_reg(@reg_number, @company_name)
 end
 
 When(/^the flagged conviction is rejected by an agency user$/) do
-  reject_flagged_conviction_for_reg(@registration_number, @company_name)
+  reject_flagged_conviction_for_reg(@reg_number, @company_name)
 end

--- a/features/step_definitions/back_office/upper_tier/finance_admin_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/finance_admin_steps.rb
@@ -1,0 +1,67 @@
+Given(/^an agency-refund-payment-user refunds the WorldPay payment$/) do
+
+  sign_out_of_back_office
+  sign_in_to_back_office("agency_user_with_payment_refund")
+  go_to_payments_page(@reg_number)
+
+  @bo.finance_payment_details_page.refund_button.click
+  expect(@bo.finance_refund_select_page.heading).to have_text("Which payment do you want to refund?")
+
+  # Use hidden text to identify correct refund link.
+  # This only works if there is only one WorldPay payment that can be refunded on page:
+  find_link("by Card").click
+
+  # The refund itself is a simple page which does not need its own page object:
+  expect(@journey.standard_page.heading).to have_text("Confirm the payment refund")
+
+  # Store amount to be refunded as text, for later steps:
+  @refund = (-@reg_balance).to_s
+
+  expect(@journey.standard_page.content).to have_text("Balance that will be refunded £" + @refund + ".00")
+  @journey.standard_page.button.click
+  # Takes user back to payment details page with flash message.
+end
+
+Then(/^the WorldPay payment is shown as refunded$/) do
+  expect(@bo.finance_payment_details_page.flash_message).to have_text("£" + @refund + ".00 refunded successfully")
+  expect(@bo.finance_payment_details_page.content).to have_text("A refund has been requested for this worldpay payment -" + @refund + ".00")
+  puts "£" + @refund + ".00 WorldPay payment refunded"
+end
+
+Given(/^a finance admin user adjusts the charge by (-?\d+)$/) do |amount|
+  # input is a positive or negative integer amount
+  sign_out_of_back_office
+  sign_in_to_back_office("finance_admin")
+  go_to_payments_page(@reg_number)
+  random_number = rand(0..999_999) # to help identify transaction later
+  amount = amount.to_i
+  adjust_charge(amount, random_number)
+
+  expect(@bo.finance_payment_details_page.flash_message).to have_text("£" + amount.to_s + ".00 charge adjust completed successfully")
+  expect(@bo.finance_payment_details_page.content).to have_text("charge adjustment " + random_number.to_s)
+
+  @reg_balance += amount
+end
+
+Given(/^(?:a|an) "([^"]*)" reverses the previous payment$/) do |user|
+  sign_out_of_back_office
+  sign_in_to_back_office(user)
+  go_to_payments_page(@reg_number)
+  reverse_last_transaction
+
+  expect(@bo.finance_payment_details_page.flash_message).to have_text("reversed successfully")
+  expect(@bo.finance_payment_details_page.content).to have_text("ti esrever")
+end
+
+Given(/^(?:a|an) "([^"]*)" writes off the outstanding balance$/) do |user|
+  # An agency_user_with_payment_refund is able to write off up to +/- 5 pounds.
+  # A finance_admin user can write off any amount.
+  sign_out_of_back_office
+  sign_in_to_back_office(user)
+  go_to_payments_page(@reg_number)
+
+  write_off_outstanding_balance
+
+  expect(@bo.finance_payment_details_page.flash_message).to have_text("write off completed successfully")
+  expect(@bo.finance_payment_details_page.content).to have_text("this is a writeoff")
+end

--- a/features/step_definitions/back_office/upper_tier/finance_payment_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/finance_payment_steps.rb
@@ -1,8 +1,8 @@
-When(/^the registration's balance is (\d+)$/) do |balance|
+When(/^the registration's balance is (-?\d+)$/) do |balance|
   sign_in_to_back_office("agency_user_with_payment_refund")
 
   # Firstly, check the balance for that registration:
-  check_registration_details(@registration_number)
+  check_registration_details(@reg_number)
   check_balance(balance)
 
   # Once confirmed, set the balance variable to that value for future steps
@@ -10,12 +10,37 @@ When(/^the registration's balance is (\d+)$/) do |balance|
 
 end
 
-When(/^the transient renewal's balance is (\d+)$/) do |balance|
+When(/^the applicant chooses to pay for the registration by bank transfer ordering (\d+) copy (?:card|cards)$/) do |copy_card_number|
+  @back_app.order_page.submit(
+    copy_card_number: copy_card_number,
+    choice: :bank_transfer_payment
+  )
+  @back_app.offline_payment_page.submit
+
+  # Show "Registration pending" page
+  expect(@back_app.finish_assisted_page).to have_text("Registration pending")
+  expect(@back_app.finish_assisted_page.registration_number).to have_text("CBDU")
+
+  @reg_number = @back_app.finish_assisted_page.registration_number.text
+  puts "Registration " + @reg_number + " submitted by bank transfer with " + copy_card_number.to_s + " card(s)"
+  @reg_balance = 154 + copy_card_number * 5
+
+end
+
+When(/^I pay for my application over the phone by maestro ordering (\d+) copy (?:card|cards)$/) do |copy_card_number|
+  @back_app.order_page.submit(
+    copy_card_number: copy_card_number,
+    choice: :card_payment
+  )
+  submit_valid_card_payment
+end
+
+When(/^the transient renewal's balance is (-?\d+)$/) do |balance|
   # This step assumes that any back office user is already logged in
   # and the payment status is viewable for that renewal (it's been submitted)
 
   visit((Quke::Quke.config.custom["urls"]["back_office_renewals"]) + "/bo")
-  @bo.dashboard_page.view_transient_reg_details(search_term: @registration_number)
+  @bo.dashboard_page.view_transient_reg_details(search_term: @reg_number)
   check_balance(balance)
 
   # Once checked, set the balance variable to that value for future steps
@@ -24,20 +49,22 @@ end
 
 When(/^NCCC makes a payment of (\d+) by "([^"]*)"$/) do |amount, method|
   sign_in_as_appropriate_finance_user(method)
-  go_to_payment(@registration_number)
+  go_to_payments_page(@reg_number)
   enter_payment(amount, method)
   check_payment_confirmation_message(amount)
+  @reg_balance -= amount
 end
 
 When(/^NCCC pays the remaining balance by "([^"]*)"$/) do |method|
   sign_in_as_appropriate_finance_user(method)
-  go_to_payment(@registration_number)
+  go_to_payments_page(@reg_number)
   enter_payment(@reg_balance, method)
   check_payment_confirmation_message(@reg_balance)
+  @reg_balance = 0
 end
 
 Given(/^registration "([^"]*)" has a renewal paid by bank transfer$/) do |reg|
-  @registration_number = reg
+  @reg_number = reg
   @is_transient_renewal = true
   @business_name = "Renewal via bank transfer"
 
@@ -51,7 +78,7 @@ Given(/^registration "([^"]*)" has a renewal paid by bank transfer$/) do |reg|
     email: Quke::Quke.config.custom["accounts"]["agency_user_with_payment_refund"]["username"],
     password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
-  @bo.dashboard_page.view_reg_details(search_term: @registration_number)
+  @bo.dashboard_page.view_reg_details(search_term: @reg_number)
   @bo.registration_details_page.renew_link.click
 
   start_internal_renewal
@@ -79,4 +106,22 @@ Given(/^registration "([^"]*)" has a renewal paid by bank transfer$/) do |reg|
   @journey.registration_cards_page.submit
   @bo.payment_summary_page.submit(choice: :bank_transfer_payment)
   @bo.bank_transfer_page.submit
+end
+
+When(/^the applicant chooses to pay for the renewal by bank transfer ordering (\d+) copy (?:card|cards)$/) do |copy_card_number|
+  order_cards_during_journey(copy_card_number)
+  @bo.payment_summary_page.submit(choice: :bank_transfer_payment)
+  @bo.bank_transfer_page.submit
+end
+
+And(/^the applicant pays by bank card$/) do
+  # On the new app, the payment choice is on a different screen from order copy cards
+  if @app == "old"
+    old_order_cards_during_journey(3)
+  else
+    order_cards_during_journey(1)
+    @bo.payment_summary_page.submit(choice: :card_payment)
+  end
+  submit_valid_card_payment
+  @is_transient_renewal = false
 end

--- a/features/step_definitions/back_office/upper_tier/non_credit_card_payments_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/non_credit_card_payments_steps.rb
@@ -1,5 +1,5 @@
 When(/^I enter a cash payment for the full amount owed$/) do
-  @back_app.registrations_page.search(search_input: @registration_number)
+  @back_app.registrations_page.search(search_input: @reg_number)
   @back_app.registrations_page.search_results[0].payment_status.click
   @back_app.payment_status_page.enter_payment.click
   # Finds the amount needed to be paid and strips off the pound sign
@@ -19,7 +19,7 @@ When(/^I enter a cash payment for the full amount owed$/) do
 end
 
 When(/^I enter a cheque payment overpaying for the amount owed$/) do
-  @back_app.registrations_page.search(search_input: @registration_number)
+  @back_app.registrations_page.search(search_input: @reg_number)
   @back_app.registrations_page.search_results[0].payment_status.click
   @back_app.payment_status_page.enter_payment.click
   # Finds the amount needed to be paid and strips off the pound sign
@@ -38,7 +38,7 @@ When(/^I enter a cheque payment overpaying for the amount owed$/) do
 end
 
 When(/^I enter a postal order payment underpaying for the amount owed$/) do
-  @back_app.registrations_page.search(search_input: @registration_number)
+  @back_app.registrations_page.search(search_input: @reg_number)
   @back_app.registrations_page.search_results[0].payment_status.click
   @back_app.payment_status_page.enter_payment.click
   # Finds the amount needed to be paid and strips off the pound sign
@@ -57,7 +57,7 @@ When(/^I enter a postal order payment underpaying for the amount owed$/) do
 end
 
 When(/^I enter a bank transfer payment for the full amount owed$/) do
-  @back_app.registrations_page.search(search_input: @registration_number)
+  @back_app.registrations_page.search(search_input: @reg_number)
   @back_app.registrations_page.search_results[0].payment_status.click
   @back_app.payment_status_page.enter_payment.click
   # Finds the amount needed to be paid and strips off the pound sign
@@ -75,21 +75,21 @@ When(/^I enter a bank transfer payment for the full amount owed$/) do
 end
 
 Then(/^the payment status will be marked as overpaid$/) do
-  @back_app.registrations_page.search(search_input: @registration_number)
+  @back_app.registrations_page.search(search_input: @reg_number)
   @back_app.registrations_page.search_results[0].payment_status.click
   expect(@back_app.payment_status_page.payment_status.text).to eq("Overpaid by")
   expect(@back_app.payment_status_page.balance.text).to eq("1.00")
 end
 
 Then(/^the payment status will be marked as underpaid$/) do
-  @back_app.registrations_page.search(search_input: @registration_number)
+  @back_app.registrations_page.search(search_input: @reg_number)
   @back_app.registrations_page.search_results[0].payment_status.click
   expect(@back_app.payment_status_page.payment_status.text).to eq("Awaiting payment")
   expect(@back_app.payment_status_page.balance.text).to eq("1.00")
 end
 
 Then(/^the registration will be marked as "([^"]*)"$/) do |status|
-  @back_app.registrations_page.search(search_input: @registration_number)
+  @back_app.registrations_page.search(search_input: @reg_number)
   expect(@back_app.registrations_page.search_results[0].status.text).to eq(status)
 
 end

--- a/features/step_definitions/back_office/upper_tier/write_off_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/write_off_steps.rb
@@ -1,12 +1,12 @@
 When(/^I write off the small amount owed$/) do
-  @back_app.registrations_page.search(search_input: @registration_number)
+  @back_app.registrations_page.search(search_input: @reg_number)
   @back_app.registrations_page.search_results[0].payment_status.click
   @back_app.payment_status_page.write_off_small.click
   @back_app.write_offs_page.submit(comment: "small amount written off")
 end
 
 When(/^I write off the large amount owed$/) do
-  @back_app.registrations_page.search(search_input: @registration_number)
+  @back_app.registrations_page.search(search_input: @reg_number)
   @back_app.registrations_page.search_results[0].payment_status.click
   @back_app.payment_status_page.write_off_large.click
   @back_app.write_offs_page.submit(comment: "large amount written off")
@@ -19,7 +19,7 @@ Then(/^the payment status will be marked as paid$/) do
 end
 
 When(/^I view the registrations payment summary$/) do
-  @back_app.registrations_page.search(search_input: @registration_number)
+  @back_app.registrations_page.search(search_input: @reg_number)
   @back_app.registrations_page.search_results[0].payment_status.click
 end
 

--- a/features/step_definitions/front_office/delete_registration_steps.rb
+++ b/features/step_definitions/front_office/delete_registration_steps.rb
@@ -7,10 +7,10 @@ Given(/I choose to delete my registration "([^"]*)"$/) do |reg_no|
     email: Quke::Quke.config.custom["accounts"]["waste_carrier2"]["username"],
     password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
-  @registration_number = reg_no
+  @reg_number = reg_no
   # Looks for registration on each page of the registrations dashboard
-  @front_app.waste_carrier_registrations_page.find_registration(@registration_number)
-  @front_app.waste_carrier_registrations_page.delete(@registration_number)
+  @front_app.waste_carrier_registrations_page.find_registration(@reg_number)
+  @front_app.waste_carrier_registrations_page.delete(@reg_number)
 
 end
 

--- a/features/step_definitions/front_office/general_steps.rb
+++ b/features/step_definitions/front_office/general_steps.rb
@@ -26,8 +26,8 @@ Then(/^I will be registered as an upper tier waste carrier$/) do
   expect(@front_app.confirmation_page.registration_number).to have_text("CBDU")
   expect(@front_app.confirmation_page).to have_text @email_address
   # Stores registration number for later use
-  @registration_number = @front_app.confirmation_page.registration_number.text
-  puts "Upper tier registration " + @registration_number + " completed"
+  @reg_number = @front_app.confirmation_page.registration_number.text
+  puts "Upper tier registration " + @reg_number + " completed"
 end
 
 Then(/^I will be registered as a lower tier waste carrier$/) do
@@ -35,17 +35,17 @@ Then(/^I will be registered as a lower tier waste carrier$/) do
     expect(@front_app.confirmation_page.registration_number).to have_text("CBDL")
     expect(@front_app.confirmation_page).to have_text @email_address
     # Stores registration number for later use
-    @registration_number = @front_app.confirmation_page.registration_number.text
+    @reg_number = @front_app.confirmation_page.registration_number.text
   else
     within_window @new_window do
       @front_app.confirmation_page.wait_until_registration_number_visible
       expect(@front_app.confirmation_page.registration_number).to have_text("CBDL")
       expect(@front_app.confirmation_page).to have_text @email
       # Stores registration number for later use
-      @registration_number = @front_app.confirmation_page.registration_number.text
+      @reg_number = @front_app.confirmation_page.registration_number.text
     end
   end
-  puts "Lower tier registration " + @registration_number + " completed"
+  puts "Lower tier registration " + @reg_number + " completed"
 end
 
 When(/^I select that I don't know what business type to enter$/) do
@@ -68,7 +68,7 @@ Then(/^I will be informed my registration is pending payment$/) do
   expect(@front_app.confirmation_page).to have_text "Application received"
   expect(@front_app.confirmation_page).to have_text @email_address
   # Stores registration number for later use
-  @registration_number = @front_app.confirmation_page.registration_number.text
+  @reg_number = @front_app.confirmation_page.registration_number.text
 end
 
 When(/^I have signed into my account$/) do
@@ -95,7 +95,7 @@ Given(/^I choose to renew my registration using my previous registration number$
   @journey = JourneyApp.new
   @front_app.start_page.load
   @front_app.start_page.submit(renewal: true)
-  @front_app.existing_registration_page.submit(reg_no: @registration_number)
+  @front_app.existing_registration_page.submit(reg_no: @reg_number)
 end
 
 Then(/^I will be told "([^"]*)"$/) do |message|

--- a/features/step_definitions/front_office/limited_company_new_upper_tier_registration_steps.rb
+++ b/features/step_definitions/front_office/limited_company_new_upper_tier_registration_steps.rb
@@ -33,7 +33,6 @@ When(/^I complete my application of my limited company as an upper tier waste ca
   )
 end
 
-# rubocop:disable Layout/LineLength
 Given(/^(?:my|a) limited company with companies house number "([^"]*)" registers as an upper tier waste carrier$/) do |no|
   @front_app = FrontOfficeApp.new
   @journey = JourneyApp.new
@@ -83,7 +82,6 @@ Given(/^(?:my|a) limited company with companies house number "([^"]*)" registers
   expect(@front_app.confirmation_page.registration_number).to have_text("CBDU")
   expect(@front_app.confirmation_page).to have_text @email_address
   # Stores registration number for later use
-  @registration_number = @front_app.confirmation_page.registration_number.text
-  puts "Upper tier registration " + @registration_number + " completed by a limited company"
+  @reg_number = @front_app.confirmation_page.registration_number.text
+  puts "Upper tier registration " + @reg_number + " completed by a limited company"
 end
-# rubocop:enable Layout/LineLength

--- a/features/step_definitions/front_office/renewal_steps.rb
+++ b/features/step_definitions/front_office/renewal_steps.rb
@@ -5,17 +5,17 @@ Given(/^I renew my registration using my previous registration number "([^"]*)"$
   @renewals_app.start_page.submit(renewal: true)
   @renewals_app.existing_registration_page.submit(reg_no: reg)
   # save registration number for checks later on
-  @registration_number = reg
+  @reg_number = reg
 end
 
 Then(/^I will be shown the renewal information page$/) do
-  expect(@renewals_app.renewal_start_page).to have_text(@registration_number)
+  expect(@renewals_app.renewal_start_page).to have_text(@reg_number)
   expect(@renewals_app.renewal_start_page.current_url).to include "/renewal-information"
 end
 
 Then(/^I will be shown the renewal start page$/) do
   @renewals_app.renewal_start_page.wait_until_heading_visible
-  expect(@renewals_app.renewal_start_page).to have_text(@registration_number)
+  expect(@renewals_app.renewal_start_page).to have_text(@reg_number)
   expect(@renewals_app.renewal_start_page.current_url).to include "/renew/CBDU"
 end
 
@@ -30,7 +30,7 @@ Given(/^I choose to renew my registration$/) do
   @journey = JourneyApp.new
   @renewals_app.start_page.load
   @renewals_app.start_page.submit(renewal: true)
-  @renewals_app.existing_registration_page.submit(reg_no: @registration_number)
+  @renewals_app.existing_registration_page.submit(reg_no: @reg_number)
 end
 
 When(/^I enter my lower tier registration number "([^"]*)"$/) do |reg_no|
@@ -52,7 +52,7 @@ end
 
 Then(/^I will be informed my renewal is received$/) do
   expect(@renewals_app.renewal_received_page).to have_text("Renewal received")
-  expect(@renewals_app.renewal_received_page).to have_text(@registration_number)
+  expect(@renewals_app.renewal_received_page).to have_text(@reg_number)
 end
 
 When(/^I change my carrier broker dealer type to "([^"]*)"$/) do |registration_type|
@@ -94,10 +94,10 @@ end
 Given(/^I choose registration "([^"]*)" for renewal$/) do |reg_no|
   @renewals_app = RenewalsApp.new
   @journey = JourneyApp.new
-  @registration_number = reg_no
+  @reg_number = reg_no
 
-  @front_app.waste_carrier_registrations_page.find_registration(@registration_number)
-  @front_app.waste_carrier_registrations_page.renew(@registration_number)
+  @front_app.waste_carrier_registrations_page.find_registration(@reg_number)
+  @front_app.waste_carrier_registrations_page.renew(@reg_number)
 end
 
 When(/^I complete my limited company renewal steps$/) do
@@ -318,7 +318,7 @@ end
 Then(/^I will be notified my renewal is complete$/) do
   @renewals_app.renewal_complete_page.wait_until_heading_visible
   expect(@renewals_app.renewal_complete_page.heading.text).to eq("Renewal complete")
-  expect(@renewals_app.renewal_complete_page).to have_text(@registration_number)
+  expect(@renewals_app.renewal_complete_page).to have_text(@reg_number)
 
   @renewals_app.renewal_complete_page.finished_button.click
   expect(@renewals_app.waste_carrier_registrations_page.heading).to have_text("Your waste carrier registrations")
@@ -354,7 +354,7 @@ end
 Then(/^I will be notified my renewal is pending checks$/) do
   @renewals_app.renewal_received_page.wait_until_heading_visible
   expect(@renewals_app.renewal_received_page.heading.text).to eq("Application received")
-  expect(@renewals_app.renewal_received_page).to have_text(@registration_number)
+  expect(@renewals_app.renewal_received_page).to have_text(@reg_number)
   Capybara.reset_session!
 end
 
@@ -362,7 +362,7 @@ Then(/^I will be notified my renewal is pending payment$/) do
   @renewals_app.renewal_received_page.wait_until_heading_visible
   expect(@renewals_app.renewal_received_page.heading.text).to eq("Application received")
   expect(@renewals_app.renewal_received_page).to have_text("pay the renewal charge")
-  expect(@renewals_app.renewal_received_page).to have_text(@registration_number)
+  expect(@renewals_app.renewal_received_page).to have_text(@reg_number)
   Capybara.reset_session!
 end
 
@@ -379,13 +379,13 @@ When(/^view my registration on the dashboard$/) do
 end
 
 Then(/^I will see my registration "([^"]*)" has been renewed$/) do |reg|
-  @registration_number = reg
-  @renewals_app.waste_carrier_registrations_page.find_registration(@registration_number)
+  @reg_number = reg
+  @renewals_app.waste_carrier_registrations_page.find_registration(@reg_number)
 
-  status = @renewals_app.waste_carrier_registrations_page.check_status(@registration_number)
+  status = @renewals_app.waste_carrier_registrations_page.check_status(@reg_number)
   expect(status).to have_text("Active")
 
-  expect(@renewals_app.waste_carrier_registrations_page.renewable?(@registration_number)).to be false
+  expect(@renewals_app.waste_carrier_registrations_page.renewable?(@reg_number)).to be false
 end
 
 Then(/^I will be prompted to sign in to complete the renewal$/) do

--- a/features/step_definitions/front_office/upper_tier_edit_charges_steps.rb
+++ b/features/step_definitions/front_office/upper_tier_edit_charges_steps.rb
@@ -7,10 +7,10 @@ Given(/I choose to edit my registration "([^"]*)"$/) do |reg_no|
     email: Quke::Quke.config.custom["accounts"]["waste_carrier"]["username"],
     password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
-  @registration_number = reg_no
+  @reg_number = reg_no
 
-  @front_app.waste_carrier_registrations_page.find_registration(@registration_number)
-  @front_app.waste_carrier_registrations_page.edit(@registration_number)
+  @front_app.waste_carrier_registrations_page.find_registration(@reg_number)
+  @front_app.waste_carrier_registrations_page.edit(@reg_number)
 end
 
 When(/^I change my registration type to "([^"]*)"$/) do |registration_type|
@@ -107,7 +107,7 @@ Then(/^its previous registration will be "([^"]*)"$/) do |status|
     email: Quke::Quke.config.custom["accounts"]["agency_user"]["username"],
     password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
-  @back_app.registrations_page.search(search_input: @registration_number)
+  @back_app.registrations_page.search(search_input: @reg_number)
   expect(@back_app.registrations_page.search_results[0].status.text).to eq(status)
 end
 

--- a/features/step_definitions/front_office/view_certificate_steps.rb
+++ b/features/step_definitions/front_office/view_certificate_steps.rb
@@ -11,17 +11,17 @@ When(/^I choose to view my certificate for "([^"]*)"$/) do |reg_no|
     email: Quke::Quke.config.custom["accounts"]["waste_carrier2"]["username"],
     password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
-  @registration_number = reg_no
-  @front_app.waste_carrier_registrations_page.find_registration(@registration_number)
+  @reg_number = reg_no
+  @front_app.waste_carrier_registrations_page.find_registration(@reg_number)
 end
 
 Then(/^I can view my certificate of registration$/) do
   # Using https://stackoverflow.com/a/25438826
-  @front_app.waste_carrier_registrations_page.view_certificate(@registration_number)
+  @front_app.waste_carrier_registrations_page.view_certificate(@reg_number)
   new_window = windows.last
   page.within_window new_window do |_frame|
     expect(@front_app.view_certificate_page).to have_text("Certificate of Registration")
-    expect(@front_app.view_certificate_page).to have_text(@registration_number)
+    expect(@front_app.view_certificate_page).to have_text(@reg_number)
   end
 
 end

--- a/features/step_definitions/journey/order_cards_steps.rb
+++ b/features/step_definitions/journey/order_cards_steps.rb
@@ -1,5 +1,5 @@
 When(/^an agency user orders "([^"]*)" registration (?:card|cards) for "([^"]*)"$/) do |cards, reg|
-  @registration_number = reg
+  @reg_number = reg
   @number_of_cards = cards.to_i
 
   @bo.dashboard_page.view_reg_details(search_term: reg)
@@ -47,7 +47,7 @@ end
 Then(/^the card order is confirmed with cleared payment$/) do
   expect(@journey.cards_confirmation_page.confirmation_message).to have_text("Order completed.\nPayment has cleared.")
   expect(@journey.cards_confirmation_page.info_table).to have_text("£ " + (@number_of_cards * 5).to_s)
-  expect(@journey.cards_confirmation_page.info_table).to have_text(@registration_number)
+  expect(@journey.cards_confirmation_page.info_table).to have_text(@reg_number)
 
   @journey.cards_confirmation_page.go_to_search_button.click
   expect(@bo.dashboard_page.heading).to have_text("Waste carriers registrations")
@@ -57,14 +57,14 @@ Then(/^the card order is confirmed awaiting payment$/) do
   expect(@journey.cards_confirmation_page.awaiting_payment_message).to have_text("Order is awaiting payment.")
 
   @journey.cards_confirmation_page.details_for_reg_button.click
-  expect(@bo.registration_details_page.heading).to have_text("Registration " + @registration_number)
+  expect(@bo.registration_details_page.heading).to have_text("Registration " + @reg_number)
   expect(@bo.registration_details_page.content).to have_text("Payment required")
 end
 
 Then(/^the carrier receives an email saying their card order is being printed$/) do
   text_to_check = [
     "We’re printing your waste carriers registration card",
-    @registration_number,
+    @reg_number,
     "Order: " + @number_of_cards.to_s + " registration card",
     "Paid: £" + (@number_of_cards.to_i * 5).to_s + " by debit or credit card"
   ]
@@ -77,7 +77,7 @@ end
 Then(/^the carrier receives an email saying they need to pay for their card order$/) do
   text_to_check = [
     "You need to pay for your waste carriers registration card",
-    @registration_number,
+    @reg_number,
     "We cannot print the cards until we receive confirmation that you have paid",
     "You ordered " + @number_of_cards.to_s + " registration card"
   ]

--- a/features/support/finance_helpers.rb
+++ b/features/support/finance_helpers.rb
@@ -2,7 +2,7 @@
 
 def sign_in_as_appropriate_finance_user(method)
   # Select user with appropriate permissions for the payment method:
-  user = if ["cash", "cheque", "postal order"].include? method
+  user = if %w[cash cheque postal].include? method
            "agency_user_with_payment_refund"
          elsif method == "transfer"
            "finance_basic"
@@ -33,11 +33,11 @@ def check_balance(expected_balance)
 
   # The regex searches for: any number of digits . two more digits newline Open Government Licence
   # See https://www.rubyguides.com/2015/06/ruby-regex/
-  balance_on_page = page.text[/(\d+\.\d+)\nOpen Government Licence/, 1].to_f
+  balance_on_page = page.text[/(-?\d+\.\d+)\nOpen Government Licence/, 1].to_f
   expect(balance_on_page).to eq(expected_balance.to_f)
 end
 
-def go_to_payment(reg)
+def go_to_payments_page(reg)
   # Find the payment details for the registration/renewal:
   if @is_transient_renewal == true
     @bo.dashboard_page.view_transient_reg_details(search_term: reg)
@@ -46,16 +46,16 @@ def go_to_payment(reg)
   end
   @bo.registration_details_page.payment_details_link.click
   expect(@bo.finance_payment_details_page.heading).to have_text("Payment details for " + reg)
-  @bo.finance_payment_details_page.enter_payment_button.click
 end
 
 def enter_payment(amount, method)
-  # This assumes a user with finance permission is logged in and on the "which payment method" page
+  # This assumes a user with finance permission is logged in and on the payments page.
   # Amount can be a string or number.
   # List of method options is in finance_payment_method_page.rb
 
+  @bo.finance_payment_details_page.enter_payment_button.click
   @bo.finance_payment_method_page.submit(choice: method.to_sym)
-  expect(@bo.finance_payment_input_page.heading).to have_text("payment for " + @registration_number)
+  expect(@bo.finance_payment_input_page.heading).to have_text("payment for " + @reg_number)
   time = Time.new
   @bo.finance_payment_input_page.submit(
     amount: amount.to_s,
@@ -68,7 +68,38 @@ def enter_payment(amount, method)
 end
 
 def check_payment_confirmation_message(amount)
-  # rubocop:disable Layout/LineLength
   expect(@bo.finance_payment_details_page.flash_message).to have_text("£" + amount.to_s + " payment entered successfully")
-  # rubocop:enable Layout/LineLength
+end
+
+def adjust_charge(amount, random_number)
+  # Start from payments page and add a positive or negative charge
+  @bo.finance_payment_details_page.charge_adjust_button.click
+  expect(@bo.finance_charge_adjust_select_page.heading).to have_text("Make a charge adjustment for " + @reg_number)
+  submit_option = amount >= 0 ? :positive : :negative
+  @bo.finance_charge_adjust_select_page.submit(choice: submit_option)
+
+  # Enter charge adjust details
+  amount = amount.abs
+  @bo.finance_charge_adjust_input_page.submit(
+    amount: amount.to_s,
+    reference: "autoadjust",
+    reason: submit_option.to_s + " charge adjustment " + random_number.to_s
+  )
+end
+
+def reverse_last_transaction
+  # Start from payments page and reverse the last transaction available to that user (according to their permissions)
+  @bo.finance_payment_details_page.reverse_payment_button.click
+  expect(@bo.finance_reversal_select_page.heading).to have_text("Which payment do you want to reverse?")
+  @bo.finance_reversal_select_page.reverse_links.last.click
+  expect(@bo.finance_reversal_input_page.heading).to have_text("Reverse a payment for " + @reg_number)
+  @bo.finance_reversal_input_page.submit(reason: "ti esrever")
+end
+
+def write_off_outstanding_balance
+  # Start from payments page and write off whatever balance is outstanding.
+  # It assumes the currently logged in user has permission to write off the amount.
+  @bo.finance_payment_details_page.write_off_button.click
+  expect(@bo.finance_writeoff_page.heading).to have_text("Write off a difference for " + @reg_number)
+  @bo.finance_writeoff_page.submit(reason: "this is a writeoff")
 end

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -28,7 +28,7 @@ def sign_out_of_back_office
   heading = @journey.standard_page.heading.text
 
   # Bypass if already logged out:
-  return unless heading == "Waste carriers registrations"
+  return if heading != "Waste carriers registrations"
 
   @bo.dashboard_page.sign_out_link.click
   expect(@journey.standard_page.heading).to have_text("Sign in")

--- a/features/support/journey_helpers.rb
+++ b/features/support/journey_helpers.rb
@@ -235,9 +235,9 @@ def old_complete_registration_from_bo(business, tier, carrier)
   expect(@back_app.finish_assisted_page).to have_view_certificate
 
   # Stores registration number for later use
-  @registration_number = @back_app.finish_assisted_page.registration_number.text
-  puts "Registration " + @registration_number + " completed for " + tier + " tier " + business + " " + carrier
-  @registration_number
+  @reg_number = @back_app.finish_assisted_page.registration_number.text
+  puts "Registration " + @reg_number + " completed for " + tier + " tier " + business + " " + carrier
+  @reg_number
 end
 
 def check_registration_details(reg)


### PR DESCRIPTION
This PR adds tests for finance admin tasks on back office. This includes refunds, charge adjustments, reversals and writeoffs.

There are new page objects and changes to variable and step names. Also some helper functions have moved from general steps to finance steps. Finally, a couple of Rubocop exemptions have been added.

While much of this PR is refactoring, I'd appreciate a check of the updated helper functions and new page object files.

All back office tests and rubocop pass.