### PR TITLE
Check payment details links are not visible before submitting a renewal

### DIFF
--- a/features/bo_new/finance/renewal_payments.feature
+++ b/features/bo_new/finance/renewal_payments.feature
@@ -8,8 +8,10 @@ Feature: Recording of a non worldpay renewal payment and negative conviction che
 
   Scenario: Renewal paid for by bank transfer is marked as complete
       Given an Environment Agency user has signed in to the backend
-        And registration "CBDU205" has a renewal paid by bank transfer
+        And registration "CBDU205" has an unsubmitted renewal
+        And I cannot access payments until the bank transfer option is selected
         And the transient renewal's balance is 105
+
        When I search for "CBDU205" pending payment
         And I mark the renewal payment as received
        Then the expiry date should be three years from the previous expiry date
@@ -17,8 +19,10 @@ Feature: Recording of a non worldpay renewal payment and negative conviction che
 
   Scenario: Renewal paid for by bank transfer but with a conviction flag is still pending conviction check sign off
       Given an Environment Agency user has signed in to the backend
-        And registration "CBDU207" has a renewal paid by bank transfer
+        And registration "CBDU207" has an unsubmitted renewal
+        And I cannot access payments until the bank transfer option is selected
         And the transient renewal's balance is 105
+
        When I search for "CBDU207" pending payment
         And I mark the renewal payment as received
        Then the registration has a status of "CONVICTIONS"

--- a/features/step_definitions/back_office/upper_tier/finance_payment_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/finance_payment_steps.rb
@@ -63,7 +63,7 @@ When(/^NCCC pays the remaining balance by "([^"]*)"$/) do |method|
   @reg_balance = 0
 end
 
-Given(/^registration "([^"]*)" has a renewal paid by bank transfer$/) do |reg|
+Given(/^registration "([^"]*)" has an unsubmitted renewal$/) do |reg|
   @reg_number = reg
   @is_transient_renewal = true
   @business_name = "Renewal via bank transfer"
@@ -105,6 +105,18 @@ Given(/^registration "([^"]*)" has a renewal paid by bank transfer$/) do |reg|
   check_your_answers
   @journey.registration_cards_page.submit
   @bo.payment_summary_page.submit(choice: :bank_transfer_payment)
+
+end
+
+Then(/^I cannot access payments until the bank transfer option is selected$/) do
+  # Check that there is no payment details link just before submitting a renewal (see RUBY-908):
+  find_link("Registrations search").click
+  @bo.dashboard_page.view_transient_reg_details(search_term: @reg_number)
+  expect(@bo.registration_details_page).to have_no_payment_details_link
+
+  # Then submit the renewal:
+  @bo.registration_details_page.continue_as_ad_button.click
+  @bo.ad_privacy_policy_page.submit
   @bo.bank_transfer_page.submit
 end
 


### PR DESCRIPTION
We had an issue where payments on transient renewals got wiped as soon as the renewal was submitted (RUBY-908).

The fix was to remove the ability to view payments between choosing a payment method, and submitting a transient renewal.

This PR adds an extra step in the regression tests to check for this. Back office tests and rubocop pass (none others are affected).