### PR TITLE
Add permissions tests for back office

### DIFF
--- a/.config.yml
+++ b/.config.yml
@@ -83,16 +83,18 @@ custom:
       username: agency-user@wcr.gov.uk
     agency_user_with_payment_refund:
       username: agency-refund-payment-user@wcr.gov.uk
+    agency_super:
+      username: agency-super@wcr.gov.uk
     finance_admin:
       username: finance-admin-user@wcr.gov.uk
     finance_basic:
       username: finance-user@wcr.gov.uk
+    finance_super:
+      username: finance-super@wcr.gov.uk
     waste_carrier:
       username: user@example.com
     waste_carrier2:
       username: another-user@example.com
-    agency_super:
-      username: agency-super@wcr.gov.uk
 # Hide or unhide the relevant URLs for the environment you want to test:
 # Local setup
   urls:

--- a/features/bo_new/dashboard/permissions.feature
+++ b/features/bo_new/dashboard/permissions.feature
@@ -1,0 +1,32 @@
+@bo_new @upper_tier @bo_dashboard
+Feature: Check back office permissions
+  As a system administrator
+  I want to ensure users can only access what they need to
+  So that no mistakes are made
+
+Background:
+  Given an Environment Agency user has signed in to the backend
+   When NCCC partially registers an upper tier "carrier_broker_dealer" "limitedCompany" with "no convictions"
+    And the applicant pays by bank card
+    And NCCC finishes the registration
+    And NCCC makes a payment of 5 by "cash"
+    And I sign out of back office
+
+Scenario: Permissions
+   When I sign into the back office as "agency_user"
+   Then I have the correct permissions for an agency user
+
+   When I sign into the back office as "agency_user_with_payment_refund"
+   Then I have the correct permissions for an agency refund payment user
+
+   When I sign into the back office as "agency_super"
+   Then I have the correct permissions for an agency super user
+
+   When I sign into the back office as "finance_basic"
+   Then I have the correct permissions for a finance user
+
+   When I sign into the back office as "finance_admin"
+   Then I have the correct permissions for a finance admin user
+
+   When I sign into the back office as "finance_super"
+   Then I have the correct permissions for a finance super user

--- a/features/page_objects/back_office/new/finance_payment_method_page.rb
+++ b/features/page_objects/back_office/new/finance_payment_method_page.rb
@@ -12,7 +12,7 @@ class FinancePaymentMethodPage < SitePrism::Page
   element(:transfer, "#payment_form_payment_type_bank_transfer", visible: false)
   element(:missed_worldpay, "#payment_form_payment_type_worldpay_missed", visible: false)
 
-  element(:submit_button, "input[type='submit']")
+  element(:submit_button, ".button")
 
   def submit(args = {})
     case args[:choice]

--- a/features/page_objects/back_office/new/registration_details_page.rb
+++ b/features/page_objects/back_office/new/registration_details_page.rb
@@ -15,10 +15,10 @@ class RegistrationDetailsPage < SitePrism::Page
   element(:business_name, ".wcr-panel-border-all .heading-medium")
 
   element(:actions_box, ".wcr-actions--push-down")
+  element(:renew_link, "a[href*='/ad-privacy-policy/CBD']")
   element(:transfer_link, "a[href*='/transfer']")
   element(:edit_link, "a[href*='/edit']")
   element(:view_certificate_link, "a[href*='/certificate']")
-  element(:renew_link, "a[href*='/ad-privacy-policy/CBD']")
   element(:order_cards_link, "a[href*='/order-copy-cards']")
   element(:payment_details_link, "a[href*='/finance-details']")
   element(:cease_or_revoke_link, "a[href*='/cease-or-revoke']")

--- a/features/page_objects/back_office/new/sections/govuk_banner.rb
+++ b/features/page_objects/back_office/new/sections/govuk_banner.rb
@@ -5,7 +5,7 @@ class GovukBanner < SitePrism::Section
   SELECTOR ||= "#global-header".freeze
 
   element(:home_page, "#proposition-name")
-  element(:manage_users, "a[href='/bo/users']")
-  element(:conviction_checks, "a[href='/bo/convictions']")
+  element(:manage_users_link, "a[href='/bo/users']")
+  element(:conviction_checks_link, "a[href='/bo/convictions']")
 
 end

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -21,6 +21,10 @@ Given(/^I sign into the back office as "([^"]*)"$/) do |user|
   sign_in_to_back_office(user)
 end
 
+Given(/^I sign out of back office$/) do
+  sign_out_of_back_office
+end
+
 Given(/^I am signed in as an Environment Agency user with refunds$/) do
   Capybara.reset_session!
   @back_app = BackEndApp.new

--- a/features/step_definitions/back_office/permissions_steps.rb
+++ b/features/step_definitions/back_office/permissions_steps.rb
@@ -1,0 +1,147 @@
+Then(/^I have the correct permissions for an agency user$/) do
+  @bo.dashboard_page.view_reg_details(search_term: @reg_number)
+  expect(@bo.registration_details_page).to have_renew_link
+  expect(@bo.registration_details_page).to have_transfer_link
+  expect(@bo.registration_details_page).to have_edit_link
+  expect(@bo.registration_details_page).to have_view_certificate_link
+  expect(@bo.registration_details_page).to have_order_cards_link
+  expect(@bo.registration_details_page).to have_payment_details_link
+  expect(@bo.registration_details_page).to have_no_cease_or_revoke_link
+  expect(@bo.registration_details_page.govuk_banner).to have_no_manage_users_link
+  # This will soon be unavailable due to RUBY-945:
+  expect(@bo.registration_details_page.govuk_banner).to have_conviction_checks_link
+
+  go_to_payments_page(@reg_number)
+  expect(@bo.finance_payment_details_page).to have_no_enter_payment_button
+  expect(@bo.finance_payment_details_page).to have_no_reverse_payment_button
+  expect(@bo.finance_payment_details_page).to have_no_charge_adjust_button
+  expect(@bo.finance_payment_details_page).to have_no_refund_button
+  expect(@bo.finance_payment_details_page).to have_no_write_off_button
+  sign_out_of_back_office
+end
+
+Then(/^I have the correct permissions for an agency refund payment user$/) do
+  @bo.dashboard_page.view_reg_details(search_term: @reg_number)
+  expect(@bo.registration_details_page).to have_renew_link
+  expect(@bo.registration_details_page).to have_transfer_link
+  expect(@bo.registration_details_page).to have_edit_link
+  expect(@bo.registration_details_page).to have_view_certificate_link
+  expect(@bo.registration_details_page).to have_order_cards_link
+  expect(@bo.registration_details_page).to have_payment_details_link
+  expect(@bo.registration_details_page).to have_cease_or_revoke_link
+  expect(@bo.registration_details_page.govuk_banner).to have_no_manage_users_link
+  expect(@bo.registration_details_page.govuk_banner).to have_conviction_checks_link
+
+  go_to_payments_page(@reg_number)
+  expect(@bo.finance_payment_details_page).to have_enter_payment_button
+  expect(@bo.finance_payment_details_page).to have_reverse_payment_button
+  expect(@bo.finance_payment_details_page).to have_no_charge_adjust_button
+  expect(@bo.finance_payment_details_page).to have_refund_button
+  expect(@bo.finance_payment_details_page).to have_write_off_button
+
+  # Check agency-refund-payment-user cannot write off more than 5 pounds:
+  sign_out_of_back_office
+  sign_in_to_back_office("finance_admin")
+  go_to_payments_page(@reg_number)
+  adjust_charge(1, 999) # adjust charge by +1 pound, passing a dummy number for second argument
+
+  # Check that write off button is no longer available:
+  sign_out_of_back_office
+  sign_in_to_back_office("agency_user")
+  go_to_payments_page(@reg_number)
+  expect(@bo.finance_payment_details_page).to have_no_write_off_button
+
+  # Set the balance back to 5 pounds for remaining tests
+  sign_out_of_back_office
+  sign_in_to_back_office("finance_admin")
+  go_to_payments_page(@reg_number)
+  adjust_charge(-1, 999) # adjust charge by -1 pound, passing a dummy number for second argument
+  sign_out_of_back_office
+end
+
+Then(/^I have the correct permissions for an agency super user$/) do
+  @bo.dashboard_page.view_reg_details(search_term: @reg_number)
+  expect(@bo.registration_details_page).to have_renew_link
+  expect(@bo.registration_details_page).to have_transfer_link
+  expect(@bo.registration_details_page).to have_edit_link
+  expect(@bo.registration_details_page).to have_view_certificate_link
+  expect(@bo.registration_details_page).to have_order_cards_link
+  expect(@bo.registration_details_page).to have_payment_details_link
+  expect(@bo.registration_details_page).to have_cease_or_revoke_link
+  expect(@bo.registration_details_page.govuk_banner).to have_manage_users_link
+  expect(@bo.registration_details_page.govuk_banner).to have_conviction_checks_link
+
+  go_to_payments_page(@reg_number)
+  expect(@bo.finance_payment_details_page).to have_enter_payment_button
+  expect(@bo.finance_payment_details_page).to have_reverse_payment_button
+  expect(@bo.finance_payment_details_page).to have_no_charge_adjust_button
+  expect(@bo.finance_payment_details_page).to have_refund_button
+  expect(@bo.finance_payment_details_page).to have_write_off_button
+  sign_out_of_back_office
+end
+
+Then(/^I have the correct permissions for a finance user$/) do
+  @bo.dashboard_page.view_reg_details(search_term: @reg_number)
+  expect(@bo.registration_details_page).to have_no_renew_link
+  expect(@bo.registration_details_page).to have_no_transfer_link
+  expect(@bo.registration_details_page).to have_no_edit_link
+  expect(@bo.registration_details_page).to have_view_certificate_link
+  expect(@bo.registration_details_page).to have_no_order_cards_link
+  expect(@bo.registration_details_page).to have_payment_details_link
+  expect(@bo.registration_details_page).to have_no_cease_or_revoke_link
+  expect(@bo.registration_details_page.govuk_banner).to have_no_manage_users_link
+  # This will soon be unavailable due to RUBY-945:
+  expect(@bo.registration_details_page.govuk_banner).to have_conviction_checks_link
+
+  go_to_payments_page(@reg_number)
+  expect(@bo.finance_payment_details_page).to have_enter_payment_button
+  expect(@bo.finance_payment_details_page).to have_reverse_payment_button
+  expect(@bo.finance_payment_details_page).to have_no_charge_adjust_button
+  expect(@bo.finance_payment_details_page).to have_no_refund_button
+  expect(@bo.finance_payment_details_page).to have_no_write_off_button
+  sign_out_of_back_office
+end
+
+Then(/^I have the correct permissions for a finance admin user$/) do
+  @bo.dashboard_page.view_reg_details(search_term: @reg_number)
+  expect(@bo.registration_details_page).to have_no_renew_link
+  expect(@bo.registration_details_page).to have_no_transfer_link
+  expect(@bo.registration_details_page).to have_no_edit_link
+  expect(@bo.registration_details_page).to have_view_certificate_link
+  expect(@bo.registration_details_page).to have_no_order_cards_link
+  expect(@bo.registration_details_page).to have_payment_details_link
+  expect(@bo.registration_details_page).to have_no_cease_or_revoke_link
+  expect(@bo.registration_details_page.govuk_banner).to have_no_manage_users_link
+  # This will soon be unavailable due to RUBY-945:
+  expect(@bo.registration_details_page.govuk_banner).to have_conviction_checks_link
+
+  go_to_payments_page(@reg_number)
+  expect(@bo.finance_payment_details_page).to have_enter_payment_button
+  expect(@bo.finance_payment_details_page).to have_reverse_payment_button
+  expect(@bo.finance_payment_details_page).to have_charge_adjust_button
+  expect(@bo.finance_payment_details_page).to have_no_refund_button
+  expect(@bo.finance_payment_details_page).to have_write_off_button
+  sign_out_of_back_office
+end
+
+Then(/^I have the correct permissions for a finance super user$/) do
+  @bo.dashboard_page.view_reg_details(search_term: @reg_number)
+  expect(@bo.registration_details_page).to have_no_renew_link
+  expect(@bo.registration_details_page).to have_no_transfer_link
+  expect(@bo.registration_details_page).to have_no_edit_link
+  expect(@bo.registration_details_page).to have_view_certificate_link
+  expect(@bo.registration_details_page).to have_no_order_cards_link
+  expect(@bo.registration_details_page).to have_payment_details_link
+  expect(@bo.registration_details_page).to have_no_cease_or_revoke_link
+  expect(@bo.registration_details_page.govuk_banner).to have_manage_users_link
+  # This will soon be unavailable due to RUBY-945:
+  expect(@bo.registration_details_page.govuk_banner).to have_conviction_checks_link
+
+  go_to_payments_page(@reg_number)
+  expect(@bo.finance_payment_details_page).to have_enter_payment_button
+  expect(@bo.finance_payment_details_page).to have_reverse_payment_button
+  expect(@bo.finance_payment_details_page).to have_charge_adjust_button
+  expect(@bo.finance_payment_details_page).to have_no_refund_button
+  expect(@bo.finance_payment_details_page).to have_write_off_button
+  sign_out_of_back_office
+end

--- a/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
@@ -197,7 +197,7 @@ Given(/^has created an agency user for "([^"]*)"$/) do |user|
 end
 
 When(/^migrates the backend users to the back office$/) do
-  @bo.dashboard_page.govuk_banner.manage_users.click
+  @bo.dashboard_page.govuk_banner.manage_users_link.click
   expect(@bo.users_page).to_not have_text(@user)
   @bo.users_page.migrate_users.click
   @bo.migrate_page.migrate_users.click
@@ -258,7 +258,7 @@ Given(/^I renew the limited company registration declaring a conviction and payi
 end
 
 When(/^I approve the conviction check$/) do
-  @bo.dashboard_page.govuk_banner.conviction_checks.click
+  @bo.dashboard_page.govuk_banner.conviction_checks_link.click
   visit((Quke::Quke.config.custom["urls"]["back_office_renewals"]) + "/bo/transient-registrations/#{@reg_number}/convictions")
 
   @bo.convictions_bo_details_page.approve_button.click

--- a/features/step_definitions/back_office/upper_tier/finance_payment_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/finance_payment_steps.rb
@@ -136,4 +136,5 @@ And(/^the applicant pays by bank card$/) do
   end
   submit_valid_card_payment
   @is_transient_renewal = false
+  @reg_balance = 0
 end

--- a/features/support/conviction_helpers.rb
+++ b/features/support/conviction_helpers.rb
@@ -50,7 +50,7 @@ end
 
 def go_to_conviction_dashboard
   sign_in_to_back_office("agency_user")
-  @bo.dashboard_page.govuk_banner.conviction_checks.click
+  @bo.dashboard_page.govuk_banner.conviction_checks_link.click
 end
 
 def go_to_conviction_for_reg(reg)

--- a/features/support/finance_helpers.rb
+++ b/features/support/finance_helpers.rb
@@ -38,7 +38,12 @@ def check_balance(expected_balance)
 end
 
 def go_to_payments_page(reg)
-  # Find the payment details for the registration/renewal:
+  # Find the payment details for the registration/renewal.
+  # This assumes the user is already logged in anywhere in back office.
+  heading_text = @journey.standard_page.heading.text
+  return if heading_text.include?("Payment details")
+
+  find_link("Registrations search").click
   if @is_transient_renewal == true
     @bo.dashboard_page.view_transient_reg_details(search_term: reg)
   else
@@ -55,6 +60,7 @@ def enter_payment(amount, method)
 
   @bo.finance_payment_details_page.enter_payment_button.click
   @bo.finance_payment_method_page.submit(choice: method.to_sym)
+  expect(@bo.finance_payment_input_page).to have_amount
   expect(@bo.finance_payment_input_page.heading).to have_text("payment for " + @reg_number)
   time = Time.new
   @bo.finance_payment_input_page.submit(


### PR DESCRIPTION
This PR adds a new test, going through each user type on back office and checking which functionality is available to them, according to our user roles spreadsheet.

All new and changed tests, and rubocop pass.