### PR TITLE
Fix/945 restrict convictions

### DIFF
--- a/.config.yml
+++ b/.config.yml
@@ -19,7 +19,7 @@ app_host: 'http://localhost:3000'
 driver: chrome
 
 # Runs either Chrome or Firefox driver headlessly if set to true
-headless: true
+headless: false
 
 parallel: false
 

--- a/features/step_definitions/back_office/permissions_steps.rb
+++ b/features/step_definitions/back_office/permissions_steps.rb
@@ -8,8 +8,7 @@ Then(/^I have the correct permissions for an agency user$/) do
   expect(@bo.registration_details_page).to have_payment_details_link
   expect(@bo.registration_details_page).to have_no_cease_or_revoke_link
   expect(@bo.registration_details_page.govuk_banner).to have_no_manage_users_link
-  # This will soon be unavailable due to RUBY-945:
-  expect(@bo.registration_details_page.govuk_banner).to have_conviction_checks_link
+  expect(@bo.registration_details_page.govuk_banner).to have_no_conviction_checks_link
 
   go_to_payments_page(@reg_number)
   expect(@bo.finance_payment_details_page).to have_no_enter_payment_button
@@ -90,8 +89,7 @@ Then(/^I have the correct permissions for a finance user$/) do
   expect(@bo.registration_details_page).to have_payment_details_link
   expect(@bo.registration_details_page).to have_no_cease_or_revoke_link
   expect(@bo.registration_details_page.govuk_banner).to have_no_manage_users_link
-  # This will soon be unavailable due to RUBY-945:
-  expect(@bo.registration_details_page.govuk_banner).to have_conviction_checks_link
+  expect(@bo.registration_details_page.govuk_banner).to have_no_conviction_checks_link
 
   go_to_payments_page(@reg_number)
   expect(@bo.finance_payment_details_page).to have_enter_payment_button
@@ -112,8 +110,7 @@ Then(/^I have the correct permissions for a finance admin user$/) do
   expect(@bo.registration_details_page).to have_payment_details_link
   expect(@bo.registration_details_page).to have_no_cease_or_revoke_link
   expect(@bo.registration_details_page.govuk_banner).to have_no_manage_users_link
-  # This will soon be unavailable due to RUBY-945:
-  expect(@bo.registration_details_page.govuk_banner).to have_conviction_checks_link
+  expect(@bo.registration_details_page.govuk_banner).to have_no_conviction_checks_link
 
   go_to_payments_page(@reg_number)
   expect(@bo.finance_payment_details_page).to have_enter_payment_button
@@ -134,8 +131,7 @@ Then(/^I have the correct permissions for a finance super user$/) do
   expect(@bo.registration_details_page).to have_payment_details_link
   expect(@bo.registration_details_page).to have_no_cease_or_revoke_link
   expect(@bo.registration_details_page.govuk_banner).to have_manage_users_link
-  # This will soon be unavailable due to RUBY-945:
-  expect(@bo.registration_details_page.govuk_banner).to have_conviction_checks_link
+  expect(@bo.registration_details_page.govuk_banner).to have_no_conviction_checks_link
 
   go_to_payments_page(@reg_number)
   expect(@bo.finance_payment_details_page).to have_enter_payment_button

--- a/features/support/conviction_helpers.rb
+++ b/features/support/conviction_helpers.rb
@@ -49,7 +49,8 @@ def reject_flagged_conviction_for_reg(reg, company_name)
 end
 
 def go_to_conviction_dashboard
-  sign_in_to_back_office("agency_user")
+  sign_out_of_back_office
+  sign_in_to_back_office("agency_user_with_payment_refund")
   @bo.dashboard_page.govuk_banner.conviction_checks_link.click
 end
 


### PR DESCRIPTION
The ability to make convictions checks has been restricted to agency-refund and agency-super users.

This PR updates the permissions and convictions checks to reflect this.

Updated tests and rubocop pass.