### PR TITLE
Fix test to detect renewal links on front office

### DIFF
--- a/.config.yml
+++ b/.config.yml
@@ -19,7 +19,7 @@ app_host: 'http://localhost:3000'
 driver: chrome
 
 # Runs either Chrome or Firefox driver headlessly if set to true
-headless: false
+headless: true
 
 parallel: false
 

--- a/features/page_objects/front_office/registrations/waste_carrier_registrations_page.rb
+++ b/features/page_objects/front_office/registrations/waste_carrier_registrations_page.rb
@@ -1,6 +1,7 @@
 class WasteCarrierRegistrationsPage < SitePrism::Page
 
   element(:heading, ".heading-large")
+  element(:content, "#content")
 
   sections(:registration_info, "table tbody tr:nth-child(odd)") do
     element(:name, "td:nth-child(1)")
@@ -49,12 +50,6 @@ class WasteCarrierRegistrationsPage < SitePrism::Page
   def check_status(registration_number)
     element = "#" + registration_number.to_s + " .column-one-quarter:nth-child(3) li+ li"
     find(:css, element).text
-  end
-
-  def renewable?(registration_number)
-    element = "#" + registration_number.to_s + " li:nth-child(3) a"
-    element_txt = find(:css, element).text
-    element_txt.include? "Renew"
   end
 
   def find_registration(registration_number)

--- a/features/page_objects/journey/worldpay_payment_page.rb
+++ b/features/page_objects/journey/worldpay_payment_page.rb
@@ -49,7 +49,7 @@ class WorldpayPaymentPage < SitePrism::Page
     # - Cardholder failed authentication
     # - The error code is invalid. The order does not proceed to authorisation.
     within_frame verification_iframe do
-      sleep(5) # as the 3D simulator can take time to load
+      sleep(6) # as the 3D simulator can take time to load
       verification_select_response.select(args[:response]) if args.key?(:response)
       verification_submit_response.click
     end

--- a/features/step_definitions/front_office/renewal_steps.rb
+++ b/features/step_definitions/front_office/renewal_steps.rb
@@ -385,7 +385,10 @@ Then(/^I will see my registration "([^"]*)" has been renewed$/) do |reg|
   status = @renewals_app.waste_carrier_registrations_page.check_status(@reg_number)
   expect(status).to have_text("Active")
 
-  expect(@renewals_app.waste_carrier_registrations_page.renewable?(@reg_number)).to be false
+  # This variable gets all page text, including visually-hidden text, which isn't captured by default.
+  # See https://blog.tomoyukikashiro.me/post/feature-test-tips-using-capybara/#can-not-find-text
+  all_page_text = @renewals_app.waste_carrier_registrations_page.content.text(:all)
+  expect(all_page_text).not_to include "Renew registration for Ltd Company renewal"
 end
 
 Then(/^I will be prompted to sign in to complete the renewal$/) do


### PR DESCRIPTION
The test to detect whether a renewal link is visible or not was failing. As "nth-child" type selectors are often unreliable, I've updated the test to search by the hidden text in the renewal link instead. It is passing again :)