### PR TITLE
Improve convictions tests and refactor logins

### DIFF
--- a/.config.yml
+++ b/.config.yml
@@ -79,17 +79,18 @@ print_progress: false
 # available in your tests.
 custom:
   accounts:
-    agency_user:
+    # Match the property names with the start of each email address, as tests such as sign_in_to_back_office rely on this:
+    agency-user:
       username: agency-user@wcr.gov.uk
-    agency_user_with_payment_refund:
+    agency-refund-payment-user:
       username: agency-refund-payment-user@wcr.gov.uk
-    agency_super:
+    agency-super:
       username: agency-super@wcr.gov.uk
-    finance_admin:
+    finance-admin-user:
       username: finance-admin-user@wcr.gov.uk
-    finance_basic:
+    finance-user:
       username: finance-user@wcr.gov.uk
-    finance_super:
+    finance-super:
       username: finance-super@wcr.gov.uk
     waste_carrier:
       username: user@example.com

--- a/.config_Chrome63_OSX.yml
+++ b/.config_Chrome63_OSX.yml
@@ -62,13 +62,13 @@ javascript_errors: false
 # available in your tests.
 custom:
   accounts:
-    agency_user:
+    agency-user:
       username: agency-user@wcr.gov.uk
-    agency_user_with_payment_refund:
+    agency-refund-payment-user:
       username: agency-refund-payment-user@wcr.gov.uk
-    finance_admin:
+    finance-admin-user:
       username: finance-admin-user@wcr.gov.uk
-    finance_basic:
+    finance-user:
       username: finance-user@wcr.gov.uk
     waste_carrier:
       username: user@example.com

--- a/.config_Chrome64_OSX.yml
+++ b/.config_Chrome64_OSX.yml
@@ -62,13 +62,13 @@ javascript_errors: false
 # available in your tests.
 custom:
   accounts:
-    agency_user:
+    agency-user:
       username: agency-user@wcr.gov.uk
-    agency_user_with_payment_refund:
+    agency-refund-payment-user:
       username: agency-refund-payment-user@wcr.gov.uk
-    finance_admin:
+    finance-admin-user:
       username: finance-admin-user@wcr.gov.uk
-    finance_basic:
+    finance-user:
       username: finance-user@wcr.gov.uk
     waste_carrier:
       username: user@example.com

--- a/.config_Edge15_W10.yml
+++ b/.config_Edge15_W10.yml
@@ -62,13 +62,13 @@ javascript_errors: false
 # available in your tests.
 custom:
   accounts:
-    agency_user:
+    agency-user:
       username: agency-user@wcr.gov.uk
-    agency_user_with_payment_refund:
+    agency-refund-payment-user:
       username: agency-refund-payment-user@wcr.gov.uk
-    finance_admin:
+    finance-admin-user:
       username: finance-admin-user@wcr.gov.uk
-    finance_basic:
+    finance-user:
       username: finance-user@wcr.gov.uk
     waste_carrier:
       username: user@example.com

--- a/.config_Firefox58_OSX.yml
+++ b/.config_Firefox58_OSX.yml
@@ -62,13 +62,13 @@ javascript_errors: false
 # available in your tests.
 custom:
   accounts:
-    agency_user:
+    agency-user:
       username: agency-user@wcr.gov.uk
-    agency_user_with_payment_refund:
+    agency-refund-payment-user:
       username: agency-refund-payment-user@wcr.gov.uk
-    finance_admin:
+    finance-admin-user:
       username: finance-admin-user@wcr.gov.uk
-    finance_basic:
+    finance-user:
       username: finance-user@wcr.gov.uk
     waste_carrier:
       username: user@example.com

--- a/.config_Firefox59_OSX.yml
+++ b/.config_Firefox59_OSX.yml
@@ -62,13 +62,13 @@ javascript_errors: false
 # available in your tests.
 custom:
   accounts:
-    agency_user:
+    agency-user:
       username: agency-user@wcr.gov.uk
-    agency_user_with_payment_refund:
+    agency-refund-payment-user:
       username: agency-refund-payment-user@wcr.gov.uk
-    finance_admin:
+    finance-admin-user:
       username: finance-admin-user@wcr.gov.uk
-    finance_basic:
+    finance-user:
       username: finance-user@wcr.gov.uk
     waste_carrier:
       username: user@example.com

--- a/.config_Galaxy_Note_8.yml
+++ b/.config_Galaxy_Note_8.yml
@@ -62,13 +62,13 @@ javascript_errors: false
 # available in your tests.
 custom:
   accounts:
-    agency_user:
+    agency-user:
       username: agency-user@wcr.gov.uk
-    agency_user_with_payment_refund:
+    agency-refund-payment-user:
       username: agency-refund-payment-user@wcr.gov.uk
-    finance_admin:
+    finance-admin-user:
       username: finance-admin-user@wcr.gov.uk
-    finance_basic:
+    finance-user:
       username: finance-user@wcr.gov.uk
     waste_carrier:
       username: user@example.com

--- a/.config_Google_Pixel.yml
+++ b/.config_Google_Pixel.yml
@@ -62,13 +62,13 @@ javascript_errors: false
 # available in your tests.
 custom:
   accounts:
-    agency_user:
+    agency-user:
       username: agency-user@wcr.gov.uk
-    agency_user_with_payment_refund:
+    agency-refund-payment-user:
       username: agency-refund-payment-user@wcr.gov.uk
-    finance_admin:
+    finance-admin-user:
       username: finance-admin-user@wcr.gov.uk
-    finance_basic:
+    finance-user:
       username: finance-user@wcr.gov.uk
     waste_carrier:
       username: user@example.com

--- a/.config_Safari10_1_OSX.yml
+++ b/.config_Safari10_1_OSX.yml
@@ -64,13 +64,13 @@ javascript_errors: false
 # available in your tests.
 custom:
   accounts:
-    agency_user:
+    agency-user:
       username: agency-user@wcr.gov.uk
-    agency_user_with_payment_refund:
+    agency-refund-payment-user:
       username: agency-refund-payment-user@wcr.gov.uk
-    finance_admin:
+    finance-admin-user:
       username: finance-admin-user@wcr.gov.uk
-    finance_basic:
+    finance-user:
       username: finance-user@wcr.gov.uk
     waste_carrier:
       username: user@example.com

--- a/.config_Safari11_OSX.yml
+++ b/.config_Safari11_OSX.yml
@@ -63,13 +63,13 @@ javascript_errors: false
 # available in your tests.
 custom:
   accounts:
-    agency_user:
+    agency-user:
       username: agency-user@wcr.gov.uk
-    agency_user_with_payment_refund:
+    agency-refund-payment-user:
       username: agency-refund-payment-user@wcr.gov.uk
-    finance_admin:
+    finance-admin-user:
       username: finance-admin-user@wcr.gov.uk
-    finance_basic:
+    finance-user:
       username: finance-user@wcr.gov.uk
     waste_carrier:
       username: user@example.com

--- a/.config_Safari9_1_OSX.yml
+++ b/.config_Safari9_1_OSX.yml
@@ -63,13 +63,13 @@ javascript_errors: false
 # available in your tests.
 custom:
   accounts:
-    agency_user:
+    agency-user:
       username: agency-user@wcr.gov.uk
-    agency_user_with_payment_refund:
+    agency-refund-payment-user:
       username: agency-refund-payment-user@wcr.gov.uk
-    finance_admin:
+    finance-admin-user:
       username: finance-admin-user@wcr.gov.uk
-    finance_basic:
+    finance-user:
       username: finance-user@wcr.gov.uk
     waste_carrier:
       username: user@example.com

--- a/.config_chrome63_W7.yml
+++ b/.config_chrome63_W7.yml
@@ -62,13 +62,13 @@ javascript_errors: false
 # available in your tests.
 custom:
   accounts:
-    agency_user:
+    agency-user:
       username: agency-user@wcr.gov.uk
-    agency_user_with_payment_refund:
+    agency-refund-payment-user:
       username: agency-refund-payment-user@wcr.gov.uk
-    finance_admin:
+    finance-admin-user:
       username: finance-admin-user@wcr.gov.uk
-    finance_basic:
+    finance-user:
       username: finance-user@wcr.gov.uk
     waste_carrier:
       username: user@example.com

--- a/.config_edge16_W10.yml
+++ b/.config_edge16_W10.yml
@@ -62,13 +62,13 @@ javascript_errors: false
 # available in your tests.
 custom:
   accounts:
-    agency_user:
+    agency-user:
       username: agency-user@wcr.gov.uk
-    agency_user_with_payment_refund:
+    agency-refund-payment-user:
       username: agency-refund-payment-user@wcr.gov.uk
-    finance_admin:
+    finance-admin-user:
       username: finance-admin-user@wcr.gov.uk
-    finance_basic:
+    finance-user:
       username: finance-user@wcr.gov.uk
     waste_carrier:
       username: user@example.com

--- a/.config_firefox58_W8_1.yml
+++ b/.config_firefox58_W8_1.yml
@@ -62,13 +62,13 @@ javascript_errors: false
 # available in your tests.
 custom:
   accounts:
-    agency_user:
+    agency-user:
       username: agency-user@wcr.gov.uk
-    agency_user_with_payment_refund:
+    agency-refund-payment-user:
       username: agency-refund-payment-user@wcr.gov.uk
-    finance_admin:
+    finance-admin-user:
       username: finance-admin-user@wcr.gov.uk
-    finance_basic:
+    finance-user:
       username: finance-user@wcr.gov.uk
     waste_carrier:
       username: user@example.com

--- a/.config_firefox59_W10.yml
+++ b/.config_firefox59_W10.yml
@@ -62,13 +62,13 @@ javascript_errors: false
 # available in your tests.
 custom:
   accounts:
-    agency_user:
+    agency-user:
       username: agency-user@wcr.gov.uk
-    agency_user_with_payment_refund:
+    agency-refund-payment-user:
       username: agency-refund-payment-user@wcr.gov.uk
-    finance_admin:
+    finance-admin-user:
       username: finance-admin-user@wcr.gov.uk
-    finance_basic:
+    finance-user:
       username: finance-user@wcr.gov.uk
     waste_carrier:
       username: user@example.com

--- a/.config_iPhone7.yml
+++ b/.config_iPhone7.yml
@@ -62,13 +62,13 @@ javascript_errors: false
 # available in your tests.
 custom:
   accounts:
-    agency_user:
+    agency-user:
       username: agency-user@wcr.gov.uk
-    agency_user_with_payment_refund:
+    agency-refund-payment-user:
       username: agency-refund-payment-user@wcr.gov.uk
-    finance_admin:
+    finance-admin-user:
       username: finance-admin-user@wcr.gov.uk
-    finance_basic:
+    finance-user:
       username: finance-user@wcr.gov.uk
     waste_carrier:
       username: user@example.com

--- a/.config_iPhone_X.yml
+++ b/.config_iPhone_X.yml
@@ -9,7 +9,7 @@
 # will be by simply setting `app_host`. You can then use it directly using
 # Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
 # the full url each time
-# Using private IP address as currently an issue with Safari on iOS 10 and 11 
+# Using private IP address as currently an issue with Safari on iOS 10 and 11
 app_host: 'http://localhost:3000'
 
 # Tells Quke which browser to use for testing. Choices are firefox, chrome
@@ -63,13 +63,13 @@ javascript_errors: false
 # available in your tests.
 custom:
   accounts:
-    agency_user:
+    agency-user:
       username: agency-user@wcr.gov.uk
-    agency_user_with_payment_refund:
+    agency-refund-payment-user:
       username: agency-refund-payment-user@wcr.gov.uk
-    finance_admin:
+    finance-admin-user:
       username: finance-admin-user@wcr.gov.uk
-    finance_basic:
+    finance-user:
       username: finance-user@wcr.gov.uk
     waste_carrier:
       username: user@example.com
@@ -88,7 +88,7 @@ custom:
     # back_office_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
     # front_office_renewals: "http:/localhost:3002"
     # front_office_renewals_sign_in: "http://localhost:3002/users/sign_in"
-    
+
 
 # If you are running Quke behind a proxy you can configure the proxy details
 # here. You'll need either the hostname or IP of the proxy server (don't include
@@ -117,8 +117,8 @@ browserstack:
   # If you don't want to put these credentials in the config file (because you
   # want to commit it to source control), Quke will also check for the existance
   # of the environment variables BROWSERSTACK_USERNAME and BROWSERSTACK_AUTH_KEY
-  # username: 
-  # auth_key: 
+  # username:
+  # auth_key:
 
   # If you want to use local testing you must provide a key. You can find this
   # in Browserstack once logged in under settings. Its typically the same value
@@ -126,7 +126,7 @@ browserstack:
   # If you don't want to put this credential in the config file (because you
   # want to commit it to source control), Quke will also check for the existance
   # of the environment variable BROWSERSTACK_LOCAL_KEY
-  # local_key: 
+  # local_key:
 
   # Anything set under capabilities will be passed directly by Quke to
   # browserstack as means of configuring the test.

--- a/.config_ie11_W10.yml
+++ b/.config_ie11_W10.yml
@@ -62,13 +62,13 @@ javascript_errors: false
 # available in your tests.
 custom:
   accounts:
-    agency_user:
+    agency-user:
       username: agency-user@wcr.gov.uk
-    agency_user_with_payment_refund:
+    agency-refund-payment-user:
       username: agency-refund-payment-user@wcr.gov.uk
-    finance_admin:
+    finance-admin-user:
       username: finance-admin-user@wcr.gov.uk
-    finance_basic:
+    finance-user:
       username: finance-user@wcr.gov.uk
     waste_carrier:
       username: user@example.com

--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ max_wait_time: 2
 
 custom:
   accounts:
-    agency_user:
-      username: agency_user@example.gov.uk
-    finance_admin:
-      username: finance_admin@example.gov.uk
-    finance_basic:
-      username: finance_basic@example.gov.uk
-    agency_user_with_payment_refund:
-      username: agency_user_with_payment_refund@example.gov.uk
+    agency-user:
+      username: agency-user@example.gov.uk
+    finance-admin-user:
+      username: finance-admin-user@example.gov.uk
+    finance-user:
+      username: finance-user@example.gov.uk
+    agency-refund-payment-user:
+      username: agency-refund-payment-user@example.gov.uk
   urls:
     front_office: "http://domainundertest.gov.uk/registrations/start"
     front_office_sign_in: "http://domainundertest.gov.uk/users/sign_in?locale=en"

--- a/features/bo_new/dashboard/cease_and_revoke.feature
+++ b/features/bo_new/dashboard/cease_and_revoke.feature
@@ -7,7 +7,7 @@ I need to be able to deregister a registered waste carrier
 So that they no longer have a valid waste carrier licence
 
 Background:
-	Given I sign into the back office as "agency_user_with_payment_refund"
+	Given I sign into the back office as "agency-refund-payment-user"
 
   Scenario: Agency user can cease upper tier waste carrier licence
     Given I have a registration "CBDU106"

--- a/features/bo_new/dashboard/convictions.feature
+++ b/features/bo_new/dashboard/convictions.feature
@@ -27,7 +27,17 @@ Feature: Conviction checks during upper tier waste carrier registrations
       And the registration does not have a status of "CONVICTIONS"
   	  And the registration status in the registration export is set to "ACTIVE"
 
-  Scenario: A partnership with a declared conviction is marked for a conviction check
+    Given NCCC partially renews an existing registration with "convictions"
+      And the applicant pays by bank card
+      And the registration has a status of "CONVICTIONS"
+
+     When the conviction check is flagged by an agency user
+      And the flagged conviction is approved by an agency user
+
+     Then the registration does not have a status of "CONVICTIONS"
+      And the registration does not have a status of "IN PROGRESS"
+
+  Scenario: A partnership with a declared conviction is flagged, approved, renewed and rejected
     Given a conviction is declared when registering their partnership for an upper tier waste carrier
       And the registration has a status of "CONVICTIONS"
 
@@ -38,6 +48,16 @@ Feature: Conviction checks during upper tier waste carrier registrations
       And the registration does not have a status of "CONVICTIONS"
   	  And the registration status in the registration export is set to "ACTIVE"
 
+    Given NCCC partially renews an existing registration with "convictions"
+      And the applicant pays by bank card
+      And the registration has a status of "CONVICTIONS"
+
+     When the conviction check is flagged by an agency user
+      And the flagged conviction is rejected by an agency user
+
+     Then the registration has a status of "CONVICTIONS"
+      And the registration has a status of "REVOKED"
+
   Scenario: Limited company with an undeclared conviction match by name is marked for a conviction check and rejected
     Given a limited company "CACI" registers as an upper tier waste carrier
       And the registration has a status of "CONVICTIONS"
@@ -47,3 +67,14 @@ Feature: Conviction checks during upper tier waste carrier registrations
 
       Then the registration has a status of "REFUSED"
        And the registration has a status of "CONVICTIONS"
+
+  Scenario: Registration is not completed if there is an outstanding conviction
+     Given an Environment Agency user has signed in to the backend
+       And NCCC partially registers an upper tier "carrier_broker_dealer" "partnership" with "convictions"
+       And the applicant chooses to pay for the registration by bank transfer ordering 1 copy card
+       And the registration's balance is 159
+
+      When NCCC pays the remaining balance by "cash"
+      Then the registration has a status of "IN PROGRESS"
+       And the registration has a status of "CONVICTIONS"
+       And the registration does not have a status of "PAYMENT NEEDED"

--- a/features/bo_new/dashboard/order_cards.feature
+++ b/features/bo_new/dashboard/order_cards.feature
@@ -5,7 +5,7 @@ Feature: [RUBY-767] NCCC agent orders registration cards from back office
   So that I can help a waste carrier prove they are registered
 
 Background:
-	Given I sign into the back office as "agency_user"
+	Given I sign into the back office as "agency-user"
 
 Scenario: NCCC user orders one card by bank card
   When an agency user orders "1" registration card for "CBDU208"

--- a/features/bo_new/dashboard/permissions.feature
+++ b/features/bo_new/dashboard/permissions.feature
@@ -13,20 +13,20 @@ Background:
     And I sign out of back office
 
 Scenario: Permissions
-   When I sign into the back office as "agency_user"
+   When I sign into the back office as "agency-user"
    Then I have the correct permissions for an agency user
 
-   When I sign into the back office as "agency_user_with_payment_refund"
+   When I sign into the back office as "agency-refund-payment-user"
    Then I have the correct permissions for an agency refund payment user
 
-   When I sign into the back office as "agency_super"
+   When I sign into the back office as "agency-super"
    Then I have the correct permissions for an agency super user
 
-   When I sign into the back office as "finance_basic"
+   When I sign into the back office as "finance-user"
    Then I have the correct permissions for a finance user
 
-   When I sign into the back office as "finance_admin"
+   When I sign into the back office as "finance-admin-user"
    Then I have the correct permissions for a finance admin user
 
-   When I sign into the back office as "finance_super"
+   When I sign into the back office as "finance-super"
    Then I have the correct permissions for a finance super user

--- a/features/bo_new/dashboard/transfer.feature
+++ b/features/bo_new/dashboard/transfer.feature
@@ -5,7 +5,7 @@ I need to be able to change the account linked to a registration
 So that users can continue to maintain registrations even if their details change
 
   Scenario: Change the account where user has just one registration
-    Given I sign into the back office as "agency_user"
+    Given I sign into the back office as "agency-user"
       And I choose to transfer ownership of "CBDU234" to another user
      When I change the account email to "user@example.com"
      Then I see a confirmation the change has been made

--- a/features/bo_new/finance/finance_admin.feature
+++ b/features/bo_new/finance/finance_admin.feature
@@ -61,16 +61,16 @@ Feature: Finance admin
         And NCCC makes a payment of 10 by "cheque"
 
       Given the registration's balance is -5
-       When an "agency_user_with_payment_refund" reverses the previous payment
+       When an "agency-refund-payment-user" reverses the previous payment
        Then the registration has a status of "ACTIVE"
         And the registration has a status of "PAYMENT NEEDED"
 
       Given the registration's balance is 5
-       When an "agency_user_with_payment_refund" writes off the outstanding balance
+       When an "agency-refund-payment-user" writes off the outstanding balance
        Then the registration's balance is 0
         And the registration does not have a status of "PAYMENT NEEDED"
 
       Given a finance admin user adjusts the charge by 6
-       When a "finance_admin" writes off the outstanding balance
+       When a "finance-admin-user" writes off the outstanding balance
        Then the registration's balance is 0
         And the registration does not have a status of "PAYMENT NEEDED"

--- a/features/bo_new/finance/registration_payments.feature
+++ b/features/bo_new/finance/registration_payments.feature
@@ -9,7 +9,7 @@ Feature: [RUBY-826] Pay for registrations
       Given an Environment Agency user has signed in to the backend
         And NCCC partially registers an upper tier "broker_dealer" "soleTrader" with "no convictions"
         And the applicant chooses to pay for the registration by bank transfer ordering 1 copy card
-        And I sign into the back office as "agency_user"
+        And I sign into the back office as "agency-user"
         And the registration's balance is 159
 
   Scenario: Pay for registration, partly by cash, complete by cheque
@@ -35,5 +35,4 @@ Feature: [RUBY-826] Pay for registrations
         And the registration does not have a status of "PAYMENT NEEDED"
         And the back office pages show the correct registration details
         And the registration's balance is 0
-
-# To add: pay for a registration with convictions (adapt from bo_old/upper_ad_convictions_registrations)
+  

--- a/features/bo_new/renewals/assisted_digital_renewal.feature
+++ b/features/bo_new/renewals/assisted_digital_renewal.feature
@@ -10,19 +10,19 @@ Background:
 
 Scenario: Public body has their upper tier registration renewed by NCCC
   Given I choose to renew "CBDU230"
-    And I sign into the back office as "agency_user"
+    And I sign into the back office as "agency-user"
    When I renew the local authority registration
    Then the renewal is complete
 
 Scenario: Limited company has their upper tier registration renewed by NCCC
   Given I choose to renew "CBDU231"
-    And I sign into the back office as "agency_user"
+    And I sign into the back office as "agency-user"
    When I renew the limited company registration
    Then the renewal is complete
 
 Scenario: Expired registration in renewal grace window is only renewed after conviction check and payment is made
   Given I choose to renew "CBDU232"
-    And I sign into the back office as "agency_user_with_payment_refund"
+    And I sign into the back office as "agency-refund-payment-user"
     And I renew the limited company registration declaring a conviction and paying by bank transfer
     And I search for "CBDU232" pending payment
    When I mark the renewal payment as received

--- a/features/bo_new/renewals/incomplete_registration_completed_with_assistance.feature
+++ b/features/bo_new/renewals/incomplete_registration_completed_with_assistance.feature
@@ -7,6 +7,6 @@ Feature: Incomplete renewal of an upper tier public body completed by NCCC
 
 Scenario: Public body has their upper tier registration renewed by NCCC
   Given "CBDU229" has been partially renewed by the account holder
-    And I sign into the back office as "agency_user"
+    And I sign into the back office as "agency-user"
    When I complete the renewal "CBDU229" for the account holder
    Then the renewal is complete

--- a/features/bo_old/dashboard/user_management.feature
+++ b/features/bo_old/dashboard/user_management.feature
@@ -7,6 +7,6 @@ So that these users can then use the renewals service
   Scenario: Creating a agency user in the backend and then migrating the user account to have access to the back office
     Given an Agency super user has signed in to the admin area
       And has created an agency user for "test@example.com"
-     When I sign into the back office as "agency_super"
+     When I sign into the back office as "agency-super"
       And migrates the backend users to the back office
      Then the user has been added to the back office

--- a/features/page_objects/back_office/new/dashboard_page.rb
+++ b/features/page_objects/back_office/new/dashboard_page.rb
@@ -5,6 +5,7 @@ class DashboardPage < SitePrism::Page
   section(:govuk_banner, GovukBanner, GovukBanner::SELECTOR)
   element(:heading, ".heading-large")
   element(:sign_out_link, "a[href*='/bo/users/sign_out']")
+  element(:content, "#content")
 
   element(:flash_message, ".flash-message")
 

--- a/features/step_definitions/back_office/assisted_digital_new_lower_tier_registration_steps.rb
+++ b/features/step_definitions/back_office/assisted_digital_new_lower_tier_registration_steps.rb
@@ -8,7 +8,7 @@ When(/^I have my registration of my charity as a lower tier waste carrier comple
   @back_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Carolgees",
-    phone_number: "012345678"
+    phone_number: "0117 4960000"
   )
   @back_app.postal_address_page.submit
   @back_app.check_details_page.submit
@@ -24,7 +24,7 @@ When(/^I have my registration of my local authority as a lower tier waste carrie
   @back_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Carolgees",
-    phone_number: "012345678"
+    phone_number: "0117 4960000"
   )
   @back_app.postal_address_page.submit
   @back_app.check_details_page.submit
@@ -43,7 +43,7 @@ Given(/^I have my registration of my limited company as a lower tier waste carri
   @back_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Carolgees",
-    phone_number: "012345678"
+    phone_number: "0117 4960000"
   )
   @back_app.postal_address_page.submit
   @back_app.check_details_page.submit
@@ -62,7 +62,7 @@ When(/^I have my registration of my partnership as a lower tier waste carrier co
   @back_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Carolgees",
-    phone_number: "012345678"
+    phone_number: "0117 4960000"
   )
   @back_app.postal_address_page.submit
   @back_app.check_details_page.submit
@@ -81,7 +81,7 @@ When(/^I have my registration of my public body as a lower tier waste carrier co
   @back_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Carolgees",
-    phone_number: "012345678"
+    phone_number: "0117 4960000"
   )
   @back_app.postal_address_page.submit
   @back_app.check_details_page.submit
@@ -100,7 +100,7 @@ When(/^I have my sole trader business lower tier waste carrier registration comp
   @back_app.contact_details_page.submit(
     first_name: "Terry",
     last_name: "Griffiths",
-    phone_number: "012345678"
+    phone_number: "0117 4960000"
   )
   @back_app.postal_address_page.submit
   @back_app.check_details_page.submit

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -3,20 +3,21 @@ Given(/^an Environment Agency user has signed in to the backend$/) do
   load_all_apps
   @back_app.agency_sign_in_page.load
   @back_app.agency_sign_in_page.submit(
-    email: Quke::Quke.config.custom["accounts"]["agency_user"]["username"],
+    email: Quke::Quke.config.custom["accounts"]["agency-user"]["username"],
     password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
 end
 
 Given(/^I sign into the back office as "([^"]*)"$/) do |user|
   # Use this step to sign in to the back office as any of the following users:
-  # agency_user
-  # agency_user_with_payment_refund
-  # finance_admin
-  # finance_basic
+  # agency-user
+  # agency-refund-payment-user
+  # agency-super
+  # finance-user
+  # finance-admin-user
+  # finance-super
   # waste_carrier
   # waste_carrier2
-  # agency_super
   load_all_apps
   sign_in_to_back_office(user)
 end
@@ -31,7 +32,7 @@ Given(/^I am signed in as an Environment Agency user with refunds$/) do
   @bo = BackOfficeApp.new
   @back_app.agency_sign_in_page.load
   @back_app.agency_sign_in_page.submit(
-    email: Quke::Quke.config.custom["accounts"]["agency_user_with_payment_refund"]["username"],
+    email: Quke::Quke.config.custom["accounts"]["agency-refund-payment-user"]["username"],
     password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
 end
@@ -68,14 +69,14 @@ Then(/^I will have a lower tier registration$/) do
 end
 
 Then(/^the registration has a status of "([^"]*)"$/) do |status|
-  sign_in_to_back_office("agency_user")
+  sign_in_to_back_office("agency-refund-payment-user")
   @bo.dashboard_page.govuk_banner.home_page.click
   @bo.dashboard_page.submit(search_term: @reg_number)
   expect(@bo.dashboard_page.results_table).to have_text(status)
 end
 
 Then(/^the registration does not have a status of "([^"]*)"$/) do |status|
-  sign_in_to_back_office("agency_user")
+  sign_in_to_back_office("agency-refund-payment-user")
   @bo.dashboard_page.govuk_banner.home_page.click
   @bo.dashboard_page.submit(search_term: @reg_number)
   expect(@bo.dashboard_page.results_table).to have_no_text(status)
@@ -135,7 +136,7 @@ Then(/^my registration status for "([^"]*)" will be "([^"]*)"$/) do |search_item
   @bo = BackOfficeApp.new
   @back_app.agency_sign_in_page.load
   @back_app.agency_sign_in_page.submit(
-    email: Quke::Quke.config.custom["accounts"]["agency_user"]["username"],
+    email: Quke::Quke.config.custom["accounts"]["agency-user"]["username"],
     password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
   @back_app.registrations_page.search(search_input: search_item)
@@ -149,7 +150,7 @@ Then(/^(?:the|my) registration status will be "([^"]*)"$/) do |status|
   @bo = BackOfficeApp.new
   @back_app.agency_sign_in_page.load
   @back_app.agency_sign_in_page.submit(
-    email: Quke::Quke.config.custom["accounts"]["agency_user"]["username"],
+    email: Quke::Quke.config.custom["accounts"]["agency-user"]["username"],
     password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
   @back_app.registrations_page.search(search_input: @reg_number)

--- a/features/step_definitions/back_office/permissions_steps.rb
+++ b/features/step_definitions/back_office/permissions_steps.rb
@@ -16,7 +16,6 @@ Then(/^I have the correct permissions for an agency user$/) do
   expect(@bo.finance_payment_details_page).to have_no_charge_adjust_button
   expect(@bo.finance_payment_details_page).to have_no_refund_button
   expect(@bo.finance_payment_details_page).to have_no_write_off_button
-  sign_out_of_back_office
 end
 
 Then(/^I have the correct permissions for an agency refund payment user$/) do
@@ -39,23 +38,19 @@ Then(/^I have the correct permissions for an agency refund payment user$/) do
   expect(@bo.finance_payment_details_page).to have_write_off_button
 
   # Check agency-refund-payment-user cannot write off more than 5 pounds:
-  sign_out_of_back_office
-  sign_in_to_back_office("finance_admin")
+  sign_in_to_back_office("finance-admin-user")
   go_to_payments_page(@reg_number)
   adjust_charge(1, 999) # adjust charge by +1 pound, passing a dummy number for second argument
 
   # Check that write off button is no longer available:
-  sign_out_of_back_office
-  sign_in_to_back_office("agency_user")
+  sign_in_to_back_office("agency-user")
   go_to_payments_page(@reg_number)
   expect(@bo.finance_payment_details_page).to have_no_write_off_button
 
   # Set the balance back to 5 pounds for remaining tests
-  sign_out_of_back_office
-  sign_in_to_back_office("finance_admin")
+  sign_in_to_back_office("finance-admin-user")
   go_to_payments_page(@reg_number)
   adjust_charge(-1, 999) # adjust charge by -1 pound, passing a dummy number for second argument
-  sign_out_of_back_office
 end
 
 Then(/^I have the correct permissions for an agency super user$/) do
@@ -76,7 +71,6 @@ Then(/^I have the correct permissions for an agency super user$/) do
   expect(@bo.finance_payment_details_page).to have_no_charge_adjust_button
   expect(@bo.finance_payment_details_page).to have_refund_button
   expect(@bo.finance_payment_details_page).to have_write_off_button
-  sign_out_of_back_office
 end
 
 Then(/^I have the correct permissions for a finance user$/) do
@@ -97,7 +91,6 @@ Then(/^I have the correct permissions for a finance user$/) do
   expect(@bo.finance_payment_details_page).to have_no_charge_adjust_button
   expect(@bo.finance_payment_details_page).to have_no_refund_button
   expect(@bo.finance_payment_details_page).to have_no_write_off_button
-  sign_out_of_back_office
 end
 
 Then(/^I have the correct permissions for a finance admin user$/) do
@@ -118,7 +111,6 @@ Then(/^I have the correct permissions for a finance admin user$/) do
   expect(@bo.finance_payment_details_page).to have_charge_adjust_button
   expect(@bo.finance_payment_details_page).to have_no_refund_button
   expect(@bo.finance_payment_details_page).to have_write_off_button
-  sign_out_of_back_office
 end
 
 Then(/^I have the correct permissions for a finance super user$/) do
@@ -139,5 +131,4 @@ Then(/^I have the correct permissions for a finance super user$/) do
   expect(@bo.finance_payment_details_page).to have_charge_adjust_button
   expect(@bo.finance_payment_details_page).to have_no_refund_button
   expect(@bo.finance_payment_details_page).to have_write_off_button
-  sign_out_of_back_office
 end

--- a/features/step_definitions/back_office/registration_steps.rb
+++ b/features/step_definitions/back_office/registration_steps.rb
@@ -43,7 +43,7 @@ Given(/^NCCC registers a lower tier "([^"]*)"$/) do |business|
 end
 
 Then(/^the back office pages show the correct registration details$/) do
-  sign_in_to_back_office("agency_user")
+  sign_in_to_back_office("agency-user")
   check_registration_details(@reg_number)
   info_panel = @bo.registration_details_page.info_panel
   page_content = @bo.registration_details_page.content

--- a/features/step_definitions/back_office/upper_tier/assisted_digital_new_upper_tier_registration_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/assisted_digital_new_upper_tier_registration_steps.rb
@@ -9,7 +9,7 @@ When(/^I have my sole trader upper tier waste carrier application completed for 
   @back_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Debuilder",
-    phone_number: "012345678"
+    phone_number: "0117 4960000"
   )
   @back_app.postal_address_page.submit
 
@@ -34,7 +34,7 @@ When(/^I have my limited company as a upper tier waste carrier application compl
   @back_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Carolgees",
-    phone_number: "012345678"
+    phone_number: "0117 4960000"
   )
   @back_app.postal_address_page.submit
 
@@ -62,7 +62,7 @@ When(/^I have my partnership upper tier waste carrier application completed for 
   @back_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Carolgees",
-    phone_number: "012345678"
+    phone_number: "0117 4960000"
   )
   @back_app.postal_address_page.submit
 
@@ -89,7 +89,7 @@ When(/^I have my public body upper tier waste carrier application completed for 
   @back_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Debuilder",
-    phone_number: "012345678"
+    phone_number: "0117 4960000"
   )
   @back_app.postal_address_page.submit
 
@@ -103,7 +103,7 @@ end
 Given(/^a limited company with companies house number "([^"]*)" is registered as an upper tier waste carrier$/) do |ch_no|
 
   # Store company name and number for later tests:
-  @company_name = "AD UT Company convictions check ltd"
+  @business_name = "AD UT Company convictions check ltd"
   @companies_house_number = ch_no
 
   @back_app.registrations_page.new_registration.click
@@ -115,7 +115,7 @@ Given(/^a limited company with companies house number "([^"]*)" is registered as
 
   @back_app.business_details_page.submit(
     companies_house_number: @companies_house_number,
-    company_name: @company_name,
+    company_name: @business_name,
     postcode: "BS1 5AH",
     result: "HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
@@ -123,7 +123,7 @@ Given(/^a limited company with companies house number "([^"]*)" is registered as
   @back_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Carolgees",
-    phone_number: "012345678"
+    phone_number: "0117 4960000"
   )
   @back_app.postal_address_page.submit
 
@@ -146,7 +146,7 @@ Given(/^a limited company with companies house number "([^"]*)" is registered as
 end
 
 Given(/^(?:a|my) limited company "([^"]*)" registers as an upper tier waste carrier$/) do |co_name|
-  @company_name = co_name
+  @business_name = co_name
   @back_app.registrations_page.new_registration.click
   @back_app.start_page.submit
   expect(@back_app.location_page.heading).to have_text("Where is your principal place of business?")
@@ -162,7 +162,7 @@ Given(/^(?:a|my) limited company "([^"]*)" registers as an upper tier waste carr
   @back_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Carolgees",
-    phone_number: "012345678"
+    phone_number: "0117 4960000"
   )
   @back_app.postal_address_page.submit
 
@@ -187,7 +187,7 @@ end
 
 Given(/a key person with a conviction registers as a sole trader upper tier waste carrier$/) do
 
-  @company_name = "AD UT Sole Trader"
+  @business_name = "AD UT Sole Trader"
   @back_app.registrations_page.new_registration.click
   @back_app.start_page.submit
   expect(@back_app.location_page.heading).to have_text("Where is your principal place of business?")
@@ -195,14 +195,14 @@ Given(/a key person with a conviction registers as a sole trader upper tier wast
   @back_app.business_type_page.submit(org_type: "soleTrader")
   old_select_upper_tier_options("carrier_broker_dealer")
   @back_app.business_details_page.submit(
-    company_name: @company_name,
+    company_name: @business_name,
     postcode: "BS1 5AH",
     result: "HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
   @back_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Debuilder",
-    phone_number: "012345678"
+    phone_number: "0117 4960000"
   )
   @back_app.postal_address_page.submit
 
@@ -222,7 +222,7 @@ Given(/a key person with a conviction registers as a sole trader upper tier wast
 end
 
 Given(/^a conviction is declared when registering their partnership for an upper tier waste carrier$/) do
-  @company_name = "AD Upper Tier Partnership"
+  @business_name = "AD Upper Tier Partnership"
   @back_app.registrations_page.new_registration.click
   @back_app.start_page.submit
   expect(@back_app.location_page.heading).to have_text("Where is your principal place of business?")
@@ -230,14 +230,14 @@ Given(/^a conviction is declared when registering their partnership for an upper
   @back_app.business_type_page.submit(org_type: "partnership")
   old_select_upper_tier_options("carrier_broker_dealer")
   @back_app.business_details_page.submit(
-    company_name: @company_name,
+    company_name: @business_name,
     postcode: "BS1 5AH",
     result: "HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
   @back_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Carolgees",
-    phone_number: "012345678"
+    phone_number: "0117 4960000"
   )
   @back_app.postal_address_page.submit
 
@@ -247,9 +247,7 @@ Given(/^a conviction is declared when registering their partnership for an upper
   @back_app.key_people_page.add_key_person(person: people[1])
   @back_app.key_people_page.submit_key_person(person: people[2])
 
-  @back_app.relevant_convictions_page.submit(choice: :yes)
-  people = @back_app.relevant_people_page.relevant_people
-  @back_app.relevant_people_page.submit_relevant_person(person: people[0])
+  old_submit_convictions("convictions")
   @back_app.check_details_page.submit
   @back_app.order_page.submit(
     copy_card_number: 2,

--- a/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
@@ -13,7 +13,7 @@ Given(/^NCCC partially renews an existing registration with "([^"]*)"$/) do |con
   @is_transient_renewal = true
 
   # Search for registration to renew:
-  sign_in_to_back_office("agency_user")
+  sign_in_to_back_office("agency-user")
   @bo.dashboard_page.view_reg_details(search_term: @reg_number)
   @bo.registration_details_page.renew_link.click
   start_internal_renewal
@@ -32,7 +32,7 @@ Given(/^NCCC partially renews an existing registration with "([^"]*)"$/) do |con
 end
 
 Given(/^the back office pages show the correct transient renewal details$/) do
-  sign_in_to_back_office("agency_user")
+  sign_in_to_back_office("agency-user")
   @bo.dashboard_page.view_transient_reg_details(search_term: @reg_number)
 
   expect(@bo.registration_details_page.heading).to have_text("Renewal " + @reg_number)
@@ -180,7 +180,7 @@ Given(/^an Agency super user has signed in to the admin area$/) do
   @journey = JourneyApp.new
   @back_app.admin_sign_in_page.load
   @back_app.admin_sign_in_page.submit(
-    email: Quke::Quke.config.custom["accounts"]["agency_super"]["username"],
+    email: Quke::Quke.config.custom["accounts"]["agency-super"]["username"],
     password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
 end

--- a/features/step_definitions/back_office/upper_tier/conviction_checks_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/conviction_checks_steps.rb
@@ -1,15 +1,15 @@
 When(/^the conviction check is immediately approved by an agency user$/) do
-  approve_conviction_immediately_for_reg(@reg_number, @company_name)
+  approve_conviction_immediately_for_reg(@reg_number, @business_name)
 end
 
 When(/^the conviction check is flagged by an agency user$/) do
-  flag_conviction_for_reg(@reg_number, @company_name)
+  flag_conviction_for_reg(@reg_number, @business_name)
 end
 
 When(/^the flagged conviction is approved by an agency user$/) do
-  approve_flagged_conviction_for_reg(@reg_number, @company_name)
+  approve_flagged_conviction_for_reg(@reg_number, @business_name)
 end
 
 When(/^the flagged conviction is rejected by an agency user$/) do
-  reject_flagged_conviction_for_reg(@reg_number, @company_name)
+  reject_flagged_conviction_for_reg(@reg_number, @business_name)
 end

--- a/features/step_definitions/back_office/upper_tier/finance_admin_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/finance_admin_steps.rb
@@ -1,7 +1,6 @@
 Given(/^an agency-refund-payment-user refunds the WorldPay payment$/) do
 
-  sign_out_of_back_office
-  sign_in_to_back_office("agency_user_with_payment_refund")
+  sign_in_to_back_office("agency-refund-payment-user")
   go_to_payments_page(@reg_number)
 
   @bo.finance_payment_details_page.refund_button.click
@@ -30,8 +29,7 @@ end
 
 Given(/^a finance admin user adjusts the charge by (-?\d+)$/) do |amount|
   # input is a positive or negative integer amount
-  sign_out_of_back_office
-  sign_in_to_back_office("finance_admin")
+  sign_in_to_back_office("finance-admin-user")
   go_to_payments_page(@reg_number)
   random_number = rand(0..999_999) # to help identify transaction later
   amount = amount.to_i
@@ -44,7 +42,6 @@ Given(/^a finance admin user adjusts the charge by (-?\d+)$/) do |amount|
 end
 
 Given(/^(?:a|an) "([^"]*)" reverses the previous payment$/) do |user|
-  sign_out_of_back_office
   sign_in_to_back_office(user)
   go_to_payments_page(@reg_number)
   reverse_last_transaction
@@ -54,9 +51,8 @@ Given(/^(?:a|an) "([^"]*)" reverses the previous payment$/) do |user|
 end
 
 Given(/^(?:a|an) "([^"]*)" writes off the outstanding balance$/) do |user|
-  # An agency_user_with_payment_refund is able to write off up to +/- 5 pounds.
-  # A finance_admin user can write off any amount.
-  sign_out_of_back_office
+  # An agency-refund-payment-user is able to write off up to +/- 5 pounds.
+  # A finance-admin-user can write off any amount.
   sign_in_to_back_office(user)
   go_to_payments_page(@reg_number)
 

--- a/features/step_definitions/back_office/upper_tier/finance_payment_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/finance_payment_steps.rb
@@ -1,5 +1,5 @@
 When(/^the registration's balance is (-?\d+)$/) do |balance|
-  sign_in_to_back_office("agency_user_with_payment_refund")
+  sign_in_to_back_office("agency-refund-payment-user")
 
   # Firstly, check the balance for that registration:
   check_registration_details(@reg_number)
@@ -75,7 +75,7 @@ Given(/^registration "([^"]*)" has an unsubmitted renewal$/) do |reg|
 
   @bo.sign_in_page.load
   @bo.sign_in_page.submit(
-    email: Quke::Quke.config.custom["accounts"]["agency_user_with_payment_refund"]["username"],
+    email: Quke::Quke.config.custom["accounts"]["agency-refund-payment-user"]["username"],
     password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
   @bo.dashboard_page.view_reg_details(search_term: @reg_number)
@@ -135,6 +135,6 @@ And(/^the applicant pays by bank card$/) do
     @bo.payment_summary_page.submit(choice: :card_payment)
   end
   submit_valid_card_payment
-  @is_transient_renewal = false
+  @is_transient_renewal = false unless @convictions == "convictions"
   @reg_balance = 0
 end

--- a/features/step_definitions/front_office/limited_company_new_upper_tier_registration_steps.rb
+++ b/features/step_definitions/front_office/limited_company_new_upper_tier_registration_steps.rb
@@ -13,7 +13,7 @@ When(/^I complete my application of my limited company as an upper tier waste ca
   @front_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Carolgees",
-    phone_number: "012345678",
+    phone_number: "0117 4960000",
     email: @email_address
   )
   @front_app.postal_address_page.submit
@@ -54,7 +54,7 @@ Given(/^(?:my|a) limited company with companies house number "([^"]*)" registers
   @front_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Carolgees",
-    phone_number: "012345678",
+    phone_number: "0117 4960000",
     email: @email_address
   )
   @front_app.postal_address_page.submit

--- a/features/step_definitions/front_office/new_lower_tier_registration_steps.rb
+++ b/features/step_definitions/front_office/new_lower_tier_registration_steps.rb
@@ -15,7 +15,7 @@ When(/^I complete my application of my charity as a lower tier waste carrier$/) 
   @front_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Carolgees",
-    phone_number: "012345678",
+    phone_number: "0117 4960000",
     email: @email_address
   )
   @front_app.postal_address_page.submit
@@ -45,7 +45,7 @@ When(/^I complete my application of my local authority as a lower tier waste car
   @front_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Carolgees",
-    phone_number: "012345678",
+    phone_number: "0117 4960000",
     email: @email_address
   )
   @front_app.postal_address_page.submit
@@ -78,7 +78,7 @@ When(/^I complete my application of my partnership as a lower tier waste carrier
   @front_app.contact_details_page.submit(
     first_name: "Terry",
     last_name: "Griffiths",
-    phone_number: "012345678",
+    phone_number: "0117 4960000",
     email: @email_address
   )
   @front_app.postal_address_page.submit
@@ -108,7 +108,7 @@ When(/^I complete my application of my public body as a lower tier waste carrier
   @front_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Carolgees",
-    phone_number: "012345678",
+    phone_number: "0117 4960000",
     email: @email_address
   )
   @front_app.postal_address_page.submit
@@ -141,7 +141,7 @@ Given(/^I complete my application of a sole trader business as a lower tier wast
   @front_app.contact_details_page.submit(
     first_name: "Terry",
     last_name: "Griffiths",
-    phone_number: "012345678",
+    phone_number: "0117 4960000",
     email: @email_address
   )
   @front_app.postal_address_page.submit
@@ -169,12 +169,12 @@ Given(/^I complete my application of my limited company "([^"]*)" as a lower tie
     postcode: "BS1 5AH",
     result: "HORIZON HOUSE, DEANERY ROAD, BRISTOL, BS1 5AH"
   )
-  @company_name = company_name
+  @business_name = company_name
   @email_address = generate_email
   @front_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Carolgees",
-    phone_number: "012345678",
+    phone_number: "0117 4960000",
     email: @email_address
   )
   @front_app.postal_address_page.submit

--- a/features/step_definitions/front_office/new_upper_tier_registration_steps.rb
+++ b/features/step_definitions/front_office/new_upper_tier_registration_steps.rb
@@ -13,7 +13,7 @@ When(/^I complete my application of my partnership as a upper tier waste carrier
   @front_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Carolgees",
-    phone_number: "012345678",
+    phone_number: "0117 4960000",
     email: @email_address
   )
   @front_app.postal_address_page.submit
@@ -48,7 +48,7 @@ When(/^I complete my application of my public body as an upper tier waste carrie
   @front_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Debuilder",
-    phone_number: "012345678",
+    phone_number: "0117 4960000",
     email: @email_address
   )
   @front_app.postal_address_page.submit
@@ -80,7 +80,7 @@ When(/^I complete my application of my sole trader business as a upper tier wast
   @front_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Debuilder",
-    phone_number: "012345678",
+    phone_number: "0117 4960000",
     email: @email_address
   )
   @front_app.postal_address_page.submit

--- a/features/step_definitions/front_office/upper_tier_edit_charges_steps.rb
+++ b/features/step_definitions/front_office/upper_tier_edit_charges_steps.rb
@@ -104,7 +104,7 @@ Then(/^its previous registration will be "([^"]*)"$/) do |status|
   @bo = BackOfficeApp.new
   @back_app.agency_sign_in_page.load
   @back_app.agency_sign_in_page.submit(
-    email: Quke::Quke.config.custom["accounts"]["agency_user"]["username"],
+    email: Quke::Quke.config.custom["accounts"]["agency-user"]["username"],
     password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
   @back_app.registrations_page.search(search_input: @reg_number)

--- a/features/support/finance_helpers.rb
+++ b/features/support/finance_helpers.rb
@@ -3,14 +3,13 @@
 def sign_in_as_appropriate_finance_user(method)
   # Select user with appropriate permissions for the payment method:
   user = if %w[cash cheque postal].include? method
-           "agency_user_with_payment_refund"
+           "agency-refund-payment-user"
          elsif method == "transfer"
-           "finance_basic"
+           "finance-user"
          else
-           "finance_admin"
+           "finance-admin-user"
          end
 
-  sign_out_of_back_office
   sign_in_to_back_office(user)
 end
 

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -9,14 +9,20 @@ def load_all_apps
 end
 
 def sign_in_to_back_office(user)
+  # Check whether user is already logged in by visiting root page:
   visit((Quke::Quke.config.custom["urls"]["back_office_renewals"]) + "/bo")
+
+  # Return if already logged in as that user.
+  # This relies on the user property name in .config.yml being the same as the start of the user's email address:
+  return if page.text.include? "Signed in as " + user
+
+  # If user is already signed in as a different user, then sign them out:
   heading = @journey.standard_page.heading.text
+  sign_out_of_back_office if heading != "Sign in"
 
-  # Bypass if already logged in:
-  return unless heading == "Sign in"
-
+  # Then sign in as the correct user:
   @bo.sign_in_page.submit(
-    # user must match the user headings in .config.yml
+    # user must match the user headings in .config.yml:
     email: Quke::Quke.config.custom["accounts"][user]["username"],
     password: ENV["WCRS_DEFAULT_PASSWORD"]
   )

--- a/features/support/journey_helpers.rb
+++ b/features/support/journey_helpers.rb
@@ -166,7 +166,9 @@ def old_submit_convictions(convictions)
   if convictions == "no convictions"
     @back_app.relevant_convictions_page.submit(choice: :no)
   else
-    puts "Need steps to declare a conviction on old app here"
+    @back_app.relevant_convictions_page.submit(choice: :yes)
+    people = @back_app.relevant_people_page.relevant_people
+    @back_app.relevant_people_page.submit_relevant_person(person: people[0])
   end
 end
 

--- a/features_old/step_definitions/bo/application_refund_steps.rb
+++ b/features_old/step_definitions/bo/application_refund_steps.rb
@@ -19,7 +19,7 @@ Given(/^I have an application paid by credit card$/) do
   @back_app.contact_details_page.submit(
     first_name: "Bob",
     last_name: "Carolgees",
-    phone_number: "012345678"
+    phone_number: "0117 4960000"
   )
   @back_app.postal_address_page.submit
 

--- a/features_old/step_definitions/old_general_steps.rb
+++ b/features_old/step_definitions/old_general_steps.rb
@@ -5,7 +5,7 @@ Given(/^I am signed in as a finance admin$/) do
   @bo = BackOfficeApp.new
   @back_app.agency_sign_in_page.load
   @back_app.agency_sign_in_page.submit(
-    email: Quke::Quke.config.custom["accounts"]["finance_admin"]["username"],
+    email: Quke::Quke.config.custom["accounts"]["finance-admin-user"]["username"],
     password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
 end
@@ -15,7 +15,7 @@ Given(/^I am signed in as a finance user$/) do
   @bo = BackOfficeApp.new
   @back_app.agency_sign_in_page.load
   @back_app.agency_sign_in_page.submit(
-    email: Quke::Quke.config.custom["accounts"]["finance_basic"]["username"],
+    email: Quke::Quke.config.custom["accounts"]["finance-user"]["username"],
     password: ENV["WCRS_DEFAULT_PASSWORD"]
   )
 end


### PR DESCRIPTION
This PR:

- makes the sign_in_to_back_office method more intelligent by checking whether the correct user is already signed in, removing the need for sign out steps
- updates the property names for each user type, to match the dummy data
- adds extra steps to the conviction tests to increase coverage

While most of this change is refactoring, I'd appreciate a quick look at the updated features and helpers.