### PR TITLE
Rename existing StartPage to OldStartPage

### DIFF
--- a/features/page_objects/back_office/new/back_office_app.rb
+++ b/features/page_objects/back_office/new/back_office_app.rb
@@ -110,6 +110,10 @@ class BackOfficeApp
     @last_page = MigratePage.new
   end
 
+  def old_start_page
+    @last_page = OldStartPage.new
+  end
+
   def payments_page
     @last_page = PaymentsPage.new
   end
@@ -136,10 +140,6 @@ class BackOfficeApp
 
   def renewal_complete_page
     @last_page = RenewalCompletePage.new
-  end
-
-  def start_page
-    @last_page = StartPage.new
   end
 
   def sign_in_page

--- a/features/page_objects/back_office/old/back_end_app.rb
+++ b/features/page_objects/back_office/old/back_end_app.rb
@@ -117,6 +117,10 @@ class BackEndApp
     @last_page = OfflinePaymentPage.new
   end
 
+  def old_start_page
+    @last_page = OldStartPage.new
+  end
+
   def other_businesses_question_page
     @last_page = OtherBusinessesQuestionPage.new
   end
@@ -179,10 +183,6 @@ class BackEndApp
 
   def renewal_start_page
     @last_page = RenewalStartPage.new
-  end
-
-  def start_page
-    @last_page = StartPage.new
   end
 
   def service_provided_question_page

--- a/features/page_objects/front_office/registrations/front_office_app.rb
+++ b/features/page_objects/front_office/registrations/front_office_app.rb
@@ -81,6 +81,10 @@ class FrontOfficeApp
     @last_page = OfflinePaymentPage.new
   end
 
+  def old_start_page
+    @last_page = OldStartPage.new
+  end
+
   def order_page
     @last_page = OrderPage.new
   end
@@ -115,10 +119,6 @@ class FrontOfficeApp
 
   def relevant_people_page
     @last_page = RelevantPeoplePage.new
-  end
-
-  def start_page
-    @last_page = StartPage.new
   end
 
   def service_provided_question_page

--- a/features/page_objects/front_office/registrations/old_start_page.rb
+++ b/features/page_objects/front_office/registrations/old_start_page.rb
@@ -1,4 +1,4 @@
-class StartPage < SitePrism::Page
+class OldStartPage < SitePrism::Page
 
   set_url(Quke::Quke.config.custom["urls"]["front_office"])
 

--- a/features/page_objects/front_office/renewals/renewals_app.rb
+++ b/features/page_objects/front_office/renewals/renewals_app.rb
@@ -28,6 +28,10 @@ class RenewalsApp
     @last_page = LocationPage.new
   end
 
+  def old_start_page
+    @last_page = OldStartPage.new
+  end
+
   def payment_summary_page
     @last_page = PaymentSummaryPage.new
   end
@@ -46,10 +50,6 @@ class RenewalsApp
 
   def renewal_complete_page
     @last_page = RenewalCompletePage.new
-  end
-
-  def start_page
-    @last_page = StartPage.new
   end
 
   def unrenewable_page

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -44,7 +44,7 @@ end
 
 Given(/^I request assistance with a new registration$/) do
   @back_app.registrations_page.new_registration.click
-  @back_app.start_page.submit
+  @back_app.old_start_page.submit
   expect(@back_app.location_page.heading).to have_text("Where is your principal place of business?")
   @back_app.location_page.submit(choice: :england)
 end

--- a/features/step_definitions/back_office/upper_tier/assisted_digital_new_upper_tier_registration_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/assisted_digital_new_upper_tier_registration_steps.rb
@@ -107,7 +107,7 @@ Given(/^a limited company with companies house number "([^"]*)" is registered as
   @companies_house_number = ch_no
 
   @back_app.registrations_page.new_registration.click
-  @back_app.start_page.submit
+  @back_app.old_start_page.submit
   expect(@back_app.location_page.heading).to have_text("Where is your principal place of business?")
   @back_app.location_page.submit(choice: :england)
   @back_app.business_type_page.submit(org_type: "limitedCompany")
@@ -148,7 +148,7 @@ end
 Given(/^(?:a|my) limited company "([^"]*)" registers as an upper tier waste carrier$/) do |co_name|
   @business_name = co_name
   @back_app.registrations_page.new_registration.click
-  @back_app.start_page.submit
+  @back_app.old_start_page.submit
   expect(@back_app.location_page.heading).to have_text("Where is your principal place of business?")
   @back_app.location_page.submit(choice: :england)
   @back_app.business_type_page.submit(org_type: "limitedCompany")
@@ -189,7 +189,7 @@ Given(/a key person with a conviction registers as a sole trader upper tier wast
 
   @business_name = "AD UT Sole Trader"
   @back_app.registrations_page.new_registration.click
-  @back_app.start_page.submit
+  @back_app.old_start_page.submit
   expect(@back_app.location_page.heading).to have_text("Where is your principal place of business?")
   @back_app.location_page.submit(choice: :england)
   @back_app.business_type_page.submit(org_type: "soleTrader")
@@ -224,7 +224,7 @@ end
 Given(/^a conviction is declared when registering their partnership for an upper tier waste carrier$/) do
   @business_name = "AD Upper Tier Partnership"
   @back_app.registrations_page.new_registration.click
-  @back_app.start_page.submit
+  @back_app.old_start_page.submit
   expect(@back_app.location_page.heading).to have_text("Where is your principal place of business?")
   @back_app.location_page.submit(choice: :england)
   @back_app.business_type_page.submit(org_type: "partnership")

--- a/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
@@ -138,8 +138,8 @@ Given(/^"([^"]*)" has been partially renewed by the account holder$/) do |reg|
   @front_app = FrontOfficeApp.new
   @renewals_app = RenewalsApp.new
   @journey = JourneyApp.new
-  @front_app.start_page.load
-  @front_app.start_page.submit(renewal: true)
+  @front_app.old_start_page.load
+  @front_app.old_start_page.submit(renewal: true)
   @front_app.existing_registration_page.submit(reg_no: @reg_number)
   @front_app.waste_carrier_sign_in_page.submit(
     email: Quke::Quke.config.custom["accounts"]["waste_carrier"]["username"],

--- a/features/step_definitions/back_office/upper_tier/revert_to_payment_summary_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/revert_to_payment_summary_steps.rb
@@ -3,8 +3,8 @@ require "pry"
 When(/^I renew my last registration"$/) do
   @renewals_app = RenewalsApp.new
   @journey = JourneyApp.new
-  @renewals_app.start_page.load
-  @renewals_app.start_page.submit(renewal: true)
+  @renewals_app.old_start_page.load
+  @renewals_app.old_start_page.submit(renewal: true)
   @renewals_app.existing_registration_page.submit(reg_no: reg)
   # save registration number for checks later on
   @reg_number = reg
@@ -19,8 +19,8 @@ end
 Then("the user is able to complete their renewal") do
   sign_in_to_front_end_if_necessary(@email_address)
 
-  @renewals_app.start_page.load
-  @renewals_app.start_page.submit(renewal: true)
+  @renewals_app.old_start_page.load
+  @renewals_app.old_start_page.submit(renewal: true)
   @renewals_app.existing_registration_page.submit(reg_no: @reg_number)
   @renewals_app.payment_summary_page.submit(choice: :card_payment)
   submit_valid_card_payment

--- a/features/step_definitions/front_office/general_steps.rb
+++ b/features/step_definitions/front_office/general_steps.rb
@@ -1,8 +1,8 @@
 Given(/^I start a new registration$/) do
   @front_app = FrontOfficeApp.new
   @journey = JourneyApp.new
-  @front_app.start_page.load
-  @front_app.start_page.submit
+  @front_app.old_start_page.load
+  @front_app.old_start_page.submit
   # Redirects to "Where is your principal place of business?"
   expect(@front_app.location_page.heading).to have_text("Where is your principal place of business?")
   # Select England as the principal place of business:
@@ -95,8 +95,8 @@ Given(/^I choose to renew my registration using my previous registration number$
   Capybara.reset_session!
   @front_app = FrontOfficeApp.new
   @journey = JourneyApp.new
-  @front_app.start_page.load
-  @front_app.start_page.submit(renewal: true)
+  @front_app.old_start_page.load
+  @front_app.old_start_page.submit(renewal: true)
   @front_app.existing_registration_page.submit(reg_no: @reg_number)
 end
 

--- a/features/step_definitions/front_office/limited_company_new_upper_tier_registration_steps.rb
+++ b/features/step_definitions/front_office/limited_company_new_upper_tier_registration_steps.rb
@@ -71,8 +71,8 @@ end
 Given(/^(?:my|a) limited company with companies house number "([^"]*)" registers as an upper tier waste carrier$/) do |no|
   @front_app = FrontOfficeApp.new
   @journey = JourneyApp.new
-  @front_app.start_page.load
-  @front_app.start_page.submit
+  @front_app.old_start_page.load
+  @front_app.old_start_page.submit
   expect(@front_app.location_page.heading).to have_text("Where is your principal place of business?")
   @front_app.location_page.submit(choice: :england)
   @front_app.business_type_page.submit(org_type: "limitedCompany")

--- a/features/step_definitions/front_office/new_lower_tier_registration_steps.rb
+++ b/features/step_definitions/front_office/new_lower_tier_registration_steps.rb
@@ -1,8 +1,8 @@
 When(/^I complete my application of my charity as a lower tier waste carrier$/) do
   @front_app = FrontOfficeApp.new
   @journey = JourneyApp.new
-  @front_app.start_page.load
-  @front_app.start_page.submit
+  @front_app.old_start_page.load
+  @front_app.old_start_page.submit
   expect(@front_app.location_page.heading).to have_text("Where is your principal place of business?")
   @front_app.location_page.submit(choice: :england)
   @front_app.business_type_page.submit(org_type: "charity")
@@ -31,8 +31,8 @@ end
 When(/^I complete my application of my local authority as a lower tier waste carrier$/) do
   @front_app = FrontOfficeApp.new
   @journey = JourneyApp.new
-  @front_app.start_page.load
-  @front_app.start_page.submit
+  @front_app.old_start_page.load
+  @front_app.old_start_page.submit
   expect(@front_app.location_page.heading).to have_text("Where is your principal place of business?")
   @front_app.location_page.submit(choice: :england)
   @front_app.business_type_page.submit(org_type: "authority")
@@ -61,8 +61,8 @@ end
 When(/^I complete my application of my partnership as a lower tier waste carrier$/) do
   @front_app = FrontOfficeApp.new
   @journey = JourneyApp.new
-  @front_app.start_page.load
-  @front_app.start_page.submit
+  @front_app.old_start_page.load
+  @front_app.old_start_page.submit
   expect(@front_app.location_page.heading).to have_text("Where is your principal place of business?")
   @front_app.location_page.submit(choice: :england)
   @front_app.business_type_page.submit(org_type: "partnership")
@@ -94,8 +94,8 @@ end
 When(/^I complete my application of my public body as a lower tier waste carrier$/) do
   @front_app = FrontOfficeApp.new
   @journey = JourneyApp.new
-  @front_app.start_page.load
-  @front_app.start_page.submit
+  @front_app.old_start_page.load
+  @front_app.old_start_page.submit
   @front_app.business_type_page.submit(org_type: "publicBody")
   @front_app.other_businesses_question_page.submit(choice: :no)
   @front_app.construction_waste_question_page.submit(choice: :no)
@@ -124,8 +124,8 @@ end
 Given(/^I complete my application of a sole trader business as a lower tier waste carrier$/) do
   @front_app = FrontOfficeApp.new
   @journey = JourneyApp.new
-  @front_app.start_page.load
-  @front_app.start_page.submit
+  @front_app.old_start_page.load
+  @front_app.old_start_page.submit
   expect(@front_app.location_page.heading).to have_text("Where is your principal place of business?")
   @front_app.location_page.submit(choice: :england)
   @front_app.business_type_page.submit(org_type: "soleTrader")
@@ -157,8 +157,8 @@ end
 Given(/^I complete my application of my limited company "([^"]*)" as a lower tier waste carrier$/) do |company_name|
   @front_app = FrontOfficeApp.new
   @journey = JourneyApp.new
-  @front_app.start_page.load
-  @front_app.start_page.submit
+  @front_app.old_start_page.load
+  @front_app.old_start_page.submit
   expect(@front_app.location_page.heading).to have_text("Where is your principal place of business?")
   @front_app.location_page.submit(choice: :england)
   @front_app.business_type_page.submit(org_type: "limitedCompany")

--- a/features/step_definitions/front_office/renewal_steps.rb
+++ b/features/step_definitions/front_office/renewal_steps.rb
@@ -1,8 +1,8 @@
 Given(/^I renew my registration using my previous registration number "([^"]*)"$/) do |reg|
   @renewals_app = RenewalsApp.new
   @journey = JourneyApp.new
-  @renewals_app.start_page.load
-  @renewals_app.start_page.submit(renewal: true)
+  @renewals_app.old_start_page.load
+  @renewals_app.old_start_page.submit(renewal: true)
   @renewals_app.existing_registration_page.submit(reg_no: reg)
   # save registration number for checks later on
   @reg_number = reg
@@ -11,8 +11,8 @@ end
 Given(/^I renew my last registration$/) do
   @renewals_app = RenewalsApp.new
   @journey = JourneyApp.new
-  @renewals_app.start_page.load
-  @renewals_app.start_page.submit(renewal: true)
+  @renewals_app.old_start_page.load
+  @renewals_app.old_start_page.submit(renewal: true)
   @renewals_app.existing_registration_page.submit(reg_no: @reg_number)
 end
 
@@ -36,8 +36,8 @@ Given(/^I choose to renew my registration$/) do
   Capybara.reset_session!
   @renewals_app = RenewalsApp.new
   @journey = JourneyApp.new
-  @renewals_app.start_page.load
-  @renewals_app.start_page.submit(renewal: true)
+  @renewals_app.old_start_page.load
+  @renewals_app.old_start_page.submit(renewal: true)
   @renewals_app.existing_registration_page.submit(reg_no: @reg_number)
 end
 

--- a/features/support/journey_helpers.rb
+++ b/features/support/journey_helpers.rb
@@ -2,7 +2,7 @@
 
 def old_start_internal_registration
   @back_app.registrations_page.new_registration.click
-  @back_app.start_page.submit
+  @back_app.old_start_page.submit
   expect(@back_app.location_page.heading).to have_text("Where is your principal place of business?")
   @back_app.location_page.submit(choice: :england)
 end

--- a/features_old/step_definitions/bo/application_refund_steps.rb
+++ b/features_old/step_definitions/bo/application_refund_steps.rb
@@ -3,7 +3,7 @@ Given(/^I have an application paid by credit card$/) do
   step "an Environment Agency user has signed in to the backend"
 
   @back_app.registrations_page.new_registration.click
-  @back_app.start_page.submit
+  @back_app.old_start_page.submit
   expect(@back_app.location_page.heading).to have_text("Where is your principal place of business?")
   @back_app.location_page.submit(choice: :england)
   @back_app.business_type_page.submit(org_type: "limitedCompany")


### PR DESCRIPTION
Since we now have a new start page we need to free the name of the page object so that we can define a new object with that name which is what we are going to keep in the long run. This existing StartPage has been renamed as we can delete it as soon as we deploy the new functionality.