### PR TITLE
Change selectors in location page to apply to old and new version of …

### DIFF
--- a/features/page_objects/journey/location_page.rb
+++ b/features/page_objects/journey/location_page.rb
@@ -3,11 +3,11 @@ class LocationPage < SitePrism::Page
   # Where is your principal place of business?
   element(:heading, "#groupLabel")
   elements(:location, "input[name='location_form[location]']", visible: false)
-  element(:england, "#location_form_location_england", visible: false)
-  element(:wales, "#location_form_location_wales", visible: false)
-  element(:scotland, "#location_form_location_scotland", visible: false)
-  element(:northern_ireland, "#location_form_location_northern_ireland", visible: false)
-  element(:overseas, "#location_form_location_overseas", visible: false)
+  element(:england, "input[value='england']", visible: false)
+  element(:wales, "input[value='wales']", visible: false)
+  element(:scotland, "input[value='scotland']", visible: false)
+  element(:northern_ireland, "input[value='northern_ireland']", visible: false)
+  element(:overseas, "input[value='overseas']", visible: false)
   element(:heading, :xpath, "//h1[contains(text(), 'Where is your principal place of business')]")
   element(:submit_button, "input[type='submit']")
 


### PR DESCRIPTION
…the page

We recently made some fixes to the location page class which was defined more than once. When doing so, we kept one of the 3 versions without realising that it was containing selectors that were specific to the new version of the location page but not the old. This fixes the selectors to use `input[value=blah]` which will apply to both versions of the page and fix the tests