### PR TITLE
Refactor URLs

### DIFF
--- a/.config-ci.yml
+++ b/.config-ci.yml
@@ -13,5 +13,5 @@ custom:
       username: account2@example.com
       password: please123
   urls:
-    old_front_end: "https://example.com"
-    old_back_end: "https://example.com"
+    front_end: "https://example.com"
+    back_end: "https://example.com"

--- a/.config-ci.yml
+++ b/.config-ci.yml
@@ -13,5 +13,5 @@ custom:
       username: account2@example.com
       password: please123
   urls:
-    front_office: "https://example.com"
-    back_office: "https://example.com"
+    old_front_end: "https://example.com"
+    old_back_end: "https://example.com"

--- a/.config.yml
+++ b/.config.yml
@@ -72,7 +72,7 @@ print_progress: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -99,13 +99,13 @@ custom:
 # Hide or unhide the relevant URLs for the environment you want to test:
 # # Local setup
 #   urls:
-#     old_front_end: "http://localhost:3000/registrations/start"
-#     old_front_end_sign_in: "http://localhost:3000/users/sign_in"
+#     front_end: "http://localhost:3000/registrations/start"
+#     front_end_sign_in: "http://localhost:3000/users/sign_in"
 #     front_office: "http://localhost:3002/fo"
 #     front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
-#     old_back_end_dashboard: "http://localhost:3000/registrations?locale=en"
-#     old_back_end: "http://localhost:3000/agency_users/sign_in"
-#     old_back_end_admin: "http://localhost:3000/admins/sign_in"
+#     back_end_dashboard: "http://localhost:3000/registrations?locale=en"
+#     back_end: "http://localhost:3000/agency_users/sign_in"
+#     back_end_admin: "http://localhost:3000/admins/sign_in"
 #     back_office: "http://localhost:8001/bo"
 #     back_office_sign_in: "http://localhost:8001/bo/users/sign_in"
 #     mail_client: "http://localhost:1080"
@@ -115,13 +115,13 @@ custom:
 
   # # Dev setup
   # urls:
-  #   old_front_end: "https://waste-carriers-dev.aws.defra.cloud"
-  #   old_front_end_sign_in: "https://waste-carriers-dev.aws.defra.cloud/users/sign_in"
+  #   front_end: "https://waste-carriers-dev.aws.defra.cloud"
+  #   front_end_sign_in: "https://waste-carriers-dev.aws.defra.cloud/users/sign_in"
   #   front_office: "https://waste-carriers-dev.aws.defra.cloud/fo"
   #   front_office_sign_in: "https://waste-carriers-dev.aws.defra.cloud/fo/users/sign_in"
-  #   old_back_end_dashboard: "https://admin-waste-carriers-dev.aws.defra.cloud/registrations?locale=en"
-  #   old_back_end: "https://admin-waste-carriers-dev.aws.defra.cloud"
-  #   old_back_end_admin: "https://admin-waste-carriers-dev.aws.defra.cloud/agency_users/sign_in"
+  #   back_end_dashboard: "https://admin-waste-carriers-dev.aws.defra.cloud/registrations?locale=en"
+  #   back_end: "https://admin-waste-carriers-dev.aws.defra.cloud"
+  #   back_end_admin: "https://admin-waste-carriers-dev.aws.defra.cloud/agency_users/sign_in"
   #   back_office: "https://admin-waste-carriers-dev.aws.defra.cloud/bo"
   #   back_office_sign_in: "https://admin-waste-carriers-dev.aws.defra.cloud/bo/users/sign_in"
   #   mail_client: "https://www.mailinator.com"
@@ -131,13 +131,13 @@ custom:
 
   # # Test setup
   # urls:
-  #   old_front_end: "https://waste-carriers-tst.aws.defra.cloud"
-  #   old_front_end_sign_in: "https://waste-carriers-tst.aws.defra.cloud/users/sign_in"
+  #   front_end: "https://waste-carriers-tst.aws.defra.cloud"
+  #   front_end_sign_in: "https://waste-carriers-tst.aws.defra.cloud/users/sign_in"
   #   front_office: "https://waste-carriers-tst.aws.defra.cloud/fo"
   #   front_office_sign_in: "https://waste-carriers-tst.aws.defra.cloud/fo/users/sign_in"
-  #   old_back_end_dashboard: "https://admin-waste-carriers-tst.aws.defra.cloud/registrations?locale=en"
-  #   old_back_end: "https://admin-waste-carriers-tst.aws.defra.cloud"
-  #   old_back_end_admin: "https://admin-waste-carriers-tst.aws.defra.cloud/agency_users/sign_in"
+  #   back_end_dashboard: "https://admin-waste-carriers-tst.aws.defra.cloud/registrations?locale=en"
+  #   back_end: "https://admin-waste-carriers-tst.aws.defra.cloud"
+  #   back_end_admin: "https://admin-waste-carriers-tst.aws.defra.cloud/agency_users/sign_in"
   #   back_office: "https://admin-waste-carriers-tst.aws.defra.cloud/bo"
   #   back_office_sign_in: "https://admin-waste-carriers-tst.aws.defra.cloud/bo/users/sign_in"
   #   mail_client: "https://www.mailinator.com"
@@ -147,13 +147,13 @@ custom:
 
   # Preprod / staging setup
   urls:
-    old_front_end: "https://waste-carriers-pre.aws.defra.cloud"
-    old_front_end_sign_in: "https://waste-carriers-pre.aws.defra.cloud/users/sign_in"
+    front_end: "https://waste-carriers-pre.aws.defra.cloud"
+    front_end_sign_in: "https://waste-carriers-pre.aws.defra.cloud/users/sign_in"
     front_office: "https://waste-carriers-pre.aws.defra.cloud/fo"
     front_office_sign_in: "https://waste-carriers-pre.aws.defra.cloud/fo/users/sign_in"
-    old_back_end_dashboard: "https://admin-waste-carriers-pre.aws.defra.cloud/registrations?locale=en"
-    old_back_end: "https://admin-waste-carriers-pre.aws.defra.cloud"
-    old_back_end_admin: "https://admin-waste-carriers-pre.aws.defra.cloud/agency_users/sign_in"
+    back_end_dashboard: "https://admin-waste-carriers-pre.aws.defra.cloud/registrations?locale=en"
+    back_end: "https://admin-waste-carriers-pre.aws.defra.cloud"
+    back_end_admin: "https://admin-waste-carriers-pre.aws.defra.cloud/agency_users/sign_in"
     back_office: "https://admin-waste-carriers-pre.aws.defra.cloud/bo"
     back_office_sign_in: "https://admin-waste-carriers-pre.aws.defra.cloud/bo/users/sign_in"
     mail_client: "https://www.mailinator.com"

--- a/.config.yml
+++ b/.config.yml
@@ -9,10 +9,10 @@
 # will be by simply setting `app_host`. You can then use it directly using
 # Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
 # the full url each time
-app_host: 'http://localhost:3000'
+# app_host: 'http://localhost:3000'
 # app_host: 'https://waste-carriers-dev.aws.defra.cloud'
 # app_host: 'https://waste-carriers-tst.aws.defra.cloud'
-# app_host: 'https://waste-carriers-pre.aws.defra.cloud'
+app_host: 'https://waste-carriers-pre.aws.defra.cloud'
 
 # Tells Quke which browser to use for testing. Choices are firefox, chrome
 # browserstack and phantomjs, with the default being phantomjs
@@ -72,7 +72,7 @@ print_progress: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -97,33 +97,33 @@ custom:
     waste_carrier2:
       username: another-user@example.com
 # Hide or unhide the relevant URLs for the environment you want to test:
-# Local setup
-  urls:
-    front_office: "http://localhost:3000/registrations/start"
-    front_office_sign_in: "http://localhost:3000/users/sign_in"
-    front_office_renewals: "http://localhost:3002"
-    front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
-    back_end_dashboard: "http://localhost:3000/registrations?locale=en"
-    back_office: "http://localhost:3000/agency_users/sign_in"
-    back_office_renewals: "http://localhost:8001"
-    back_office_renewals_sign_in: "http://localhost:8001/bo/users/sign_in"
-    backend_admin: "http://localhost:3000/admins/sign_in"
-    mail_client: "http://localhost:1080"
-    last_email_fe: "http://localhost:3000/email/last-email"
-    last_email_fo: "http://localhost:3002/fo/email/last-email"
-    last_email_bo: "http://localhost:8001/bo/email/last-email"
+# # Local setup
+#   urls:
+#     old_front_end: "http://localhost:3000/registrations/start"
+#     old_front_end_sign_in: "http://localhost:3000/users/sign_in"
+#     front_office: "http://localhost:3002/fo"
+#     front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
+#     old_back_end_dashboard: "http://localhost:3000/registrations?locale=en"
+#     old_back_end: "http://localhost:3000/agency_users/sign_in"
+#     old_back_end_admin: "http://localhost:3000/admins/sign_in"
+#     back_office: "http://localhost:8001/bo"
+#     back_office_sign_in: "http://localhost:8001/bo/users/sign_in"
+#     mail_client: "http://localhost:1080"
+#     last_email_fe: "http://localhost:3000/email/last-email"
+#     last_email_fo: "http://localhost:3002/fo/email/last-email"
+#     last_email_bo: "http://localhost:8001/bo/email/last-email"
 
   # # Dev setup
   # urls:
-  #   front_office: "https://waste-carriers-dev.aws.defra.cloud"
-  #   front_office_sign_in: "https://waste-carriers-dev.aws.defra.cloud/users/sign_in"
-  #   front_office_renewals: "https://waste-carriers-dev.aws.defra.cloud"
-  #   front_office_renewals_sign_in: "https://waste-carriers-dev.aws.defra.cloud/fo/users/sign_in"
-  #   back_end_dashboard: "https://admin-waste-carriers-dev.aws.defra.cloud/registrations?locale=en"
-  #   back_office: "https://admin-waste-carriers-dev.aws.defra.cloud"
-  #   back_office_admin: "https://admin-waste-carriers-dev.aws.defra.cloud/agency_users/sign_in"
-  #   back_office_renewals: "https://admin-waste-carriers-dev.aws.defra.cloud/"
-  #   back_office_renewals_sign_in: "https://admin-waste-carriers-dev.aws.defra.cloud/bo/users/sign_in"
+  #   old_front_end: "https://waste-carriers-dev.aws.defra.cloud"
+  #   old_front_end_sign_in: "https://waste-carriers-dev.aws.defra.cloud/users/sign_in"
+  #   front_office: "https://waste-carriers-dev.aws.defra.cloud/fo"
+  #   front_office_sign_in: "https://waste-carriers-dev.aws.defra.cloud/fo/users/sign_in"
+  #   old_back_end_dashboard: "https://admin-waste-carriers-dev.aws.defra.cloud/registrations?locale=en"
+  #   old_back_end: "https://admin-waste-carriers-dev.aws.defra.cloud"
+  #   old_back_end_admin: "https://admin-waste-carriers-dev.aws.defra.cloud/agency_users/sign_in"
+  #   back_office: "https://admin-waste-carriers-dev.aws.defra.cloud/bo"
+  #   back_office_sign_in: "https://admin-waste-carriers-dev.aws.defra.cloud/bo/users/sign_in"
   #   mail_client: "https://www.mailinator.com"
   #   last_email_fe: "https://waste-carriers-dev.aws.defra.cloud/email/last-email"
   #   last_email_fo: "https://waste-carriers-dev.aws.defra.cloud/fo/email/last-email"
@@ -131,35 +131,35 @@ custom:
 
   # # Test setup
   # urls:
-  #   front_office: "https://waste-carriers-tst.aws.defra.cloud"
-  #   front_office_sign_in: "https://waste-carriers-tst.aws.defra.cloud/users/sign_in"
-  #   front_office_renewals: "https://waste-carriers-tst.aws.defra.cloud"
-  #   front_office_renewals_sign_in: "https://waste-carriers-tst.aws.defra.cloud/fo/users/sign_in"
-  #   back_end_dashboard: "https://admin-waste-carriers-tst.aws.defra.cloud/registrations?locale=en"
-  #   back_office: "https://admin-waste-carriers-tst.aws.defra.cloud"
-  #   back_office_admin: "https://admin-waste-carriers-tst.aws.defra.cloud/agency_users/sign_in"
-  #   back_office_renewals: "https://admin-waste-carriers-tst.aws.defra.cloud/"
-  #   back_office_renewals_sign_in: "https://admin-waste-carriers-tst.aws.defra.cloud/bo/users/sign_in"
+  #   old_front_end: "https://waste-carriers-tst.aws.defra.cloud"
+  #   old_front_end_sign_in: "https://waste-carriers-tst.aws.defra.cloud/users/sign_in"
+  #   front_office: "https://waste-carriers-tst.aws.defra.cloud/fo"
+  #   front_office_sign_in: "https://waste-carriers-tst.aws.defra.cloud/fo/users/sign_in"
+  #   old_back_end_dashboard: "https://admin-waste-carriers-tst.aws.defra.cloud/registrations?locale=en"
+  #   old_back_end: "https://admin-waste-carriers-tst.aws.defra.cloud"
+  #   old_back_end_admin: "https://admin-waste-carriers-tst.aws.defra.cloud/agency_users/sign_in"
+  #   back_office: "https://admin-waste-carriers-tst.aws.defra.cloud/bo"
+  #   back_office_sign_in: "https://admin-waste-carriers-tst.aws.defra.cloud/bo/users/sign_in"
   #   mail_client: "https://www.mailinator.com"
   #   last_email_fe: "https://waste-carriers-tst.aws.defra.cloud/email/last-email"
   #   last_email_fo: "https://waste-carriers-tst.aws.defra.cloud/fo/email/last-email"
   #   last_email_bo: "https://admin-waste-carriers-tst.aws.defra.cloud/bo/email/last-email"
 
-  # # Preprod / staging setup
-  # urls:
-  #   front_office: "https://waste-carriers-pre.aws.defra.cloud"
-  #   front_office_sign_in: "https://waste-carriers-pre.aws.defra.cloud/users/sign_in"
-  #   front_office_renewals: "https://waste-carriers-pre.aws.defra.cloud"
-  #   front_office_renewals_sign_in: "https://waste-carriers-pre.aws.defra.cloud/fo/users/sign_in"
-  #   back_end_dashboard: "https://admin-waste-carriers-pre.aws.defra.cloud/registrations?locale=en"
-  #   back_office: "https://admin-waste-carriers-pre.aws.defra.cloud"
-  #   back_office_admin: "https://admin-waste-carriers-pre.aws.defra.cloud/agency_users/sign_in"
-  #   back_office_renewals: "https://admin-waste-carriers-pre.aws.defra.cloud/"
-  #   back_office_renewals_sign_in: "https://admin-waste-carriers-pre.aws.defra.cloud/bo/users/sign_in"
-  #   mail_client: "https://www.mailinator.com"
-  #   last_email_fe: "https://waste-carriers-pre.aws.defra.cloud/email/last-email"
-  #   last_email_fo: "https://waste-carriers-pre.aws.defra.cloud/fo/email/last-email"
-  #   last_email_bo: "https://admin-waste-carriers-pre.aws.defra.cloud/bo/email/last-email"
+  # Preprod / staging setup
+  urls:
+    old_front_end: "https://waste-carriers-pre.aws.defra.cloud"
+    old_front_end_sign_in: "https://waste-carriers-pre.aws.defra.cloud/users/sign_in"
+    front_office: "https://waste-carriers-pre.aws.defra.cloud/fo"
+    front_office_sign_in: "https://waste-carriers-pre.aws.defra.cloud/fo/users/sign_in"
+    old_back_end_dashboard: "https://admin-waste-carriers-pre.aws.defra.cloud/registrations?locale=en"
+    old_back_end: "https://admin-waste-carriers-pre.aws.defra.cloud"
+    old_back_end_admin: "https://admin-waste-carriers-pre.aws.defra.cloud/agency_users/sign_in"
+    back_office: "https://admin-waste-carriers-pre.aws.defra.cloud/bo"
+    back_office_sign_in: "https://admin-waste-carriers-pre.aws.defra.cloud/bo/users/sign_in"
+    mail_client: "https://www.mailinator.com"
+    last_email_fe: "https://waste-carriers-pre.aws.defra.cloud/email/last-email"
+    last_email_fo: "https://waste-carriers-pre.aws.defra.cloud/fo/email/last-email"
+    last_email_bo: "https://admin-waste-carriers-pre.aws.defra.cloud/bo/email/last-email"
 
 # If you are running Quke behind a proxy you can configure the proxy details
 # here. You'll need either the hostname or IP of the proxy server (don't include

--- a/.config_Chrome63_OSX.yml
+++ b/.config_Chrome63_OSX.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,17 +74,17 @@ custom:
       username: user@example.com
   urls:
     # Local
-    old_front_end: "http://localhost:3000/registrations/start"
-    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_end: "http://localhost:3000/registrations/start"
+    front_end_sign_in: "http:/localhost:3000/users/sign_in"
     front_office: "http://localhost:3002"
     front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
-    old_back_end: "http:/localhost:3000/agency_users/sign_in"
-    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
+    back_end: "http:/localhost:3000/agency_users/sign_in"
+    back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
     # front_office: "http://localhost:3002"
     # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     

--- a/.config_Chrome63_OSX.yml
+++ b/.config_Chrome63_OSX.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,19 +74,19 @@ custom:
       username: user@example.com
   urls:
     # Local
-    front_office: "http://localhost:3000/registrations/start"
-    front_office_sign_in: "http:/localhost:3000/users/sign_in"
-    front_office_renewals: "http://localhost:3002"
-    front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
-    back_office: "http:/localhost:3000/agency_users/sign_in"
-    back_office_admin: "http:/localhost:3000/admins/sign_in"
+    old_front_end: "http://localhost:3000/registrations/start"
+    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_office: "http://localhost:3002"
+    front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
+    old_back_end: "http:/localhost:3000/agency_users/sign_in"
+    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # front_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # front_office_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # back_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # back_office_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
-    # front_office_renewals: "http://localhost:3002"
-    # front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
+    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_office: "http://localhost:3002"
+    # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     
 
 # If you are running Quke behind a proxy you can configure the proxy details

--- a/.config_Chrome64_OSX.yml
+++ b/.config_Chrome64_OSX.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,17 +74,17 @@ custom:
       username: user@example.com
   urls:
     # Local
-    old_front_end: "http://localhost:3000/registrations/start"
-    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_end: "http://localhost:3000/registrations/start"
+    front_end_sign_in: "http:/localhost:3000/users/sign_in"
     front_office: "http://localhost:3002"
     front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
-    old_back_end: "http:/localhost:3000/agency_users/sign_in"
-    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
+    back_end: "http:/localhost:3000/agency_users/sign_in"
+    back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
     # front_office: "http://localhost:3002"
     # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     

--- a/.config_Chrome64_OSX.yml
+++ b/.config_Chrome64_OSX.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,19 +74,19 @@ custom:
       username: user@example.com
   urls:
     # Local
-    front_office: "http://localhost:3000/registrations/start"
-    front_office_sign_in: "http:/localhost:3000/users/sign_in"
-    front_office_renewals: "http://localhost:3002"
-    front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
-    back_office: "http:/localhost:3000/agency_users/sign_in"
-    back_office_admin: "http:/localhost:3000/admins/sign_in"
+    old_front_end: "http://localhost:3000/registrations/start"
+    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_office: "http://localhost:3002"
+    front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
+    old_back_end: "http:/localhost:3000/agency_users/sign_in"
+    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # front_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # front_office_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # back_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # back_office_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
-    # front_office_renewals: "http://localhost:3002"
-    # front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
+    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_office: "http://localhost:3002"
+    # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     
 
 # If you are running Quke behind a proxy you can configure the proxy details

--- a/.config_Edge15_W10.yml
+++ b/.config_Edge15_W10.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,17 +74,17 @@ custom:
       username: user@example.com
   urls:
     # Local
-    old_front_end: "http://localhost:3000/registrations/start"
-    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_end: "http://localhost:3000/registrations/start"
+    front_end_sign_in: "http:/localhost:3000/users/sign_in"
     front_office: "http://localhost:3002"
     front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
-    old_back_end: "http:/localhost:3000/agency_users/sign_in"
-    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
+    back_end: "http:/localhost:3000/agency_users/sign_in"
+    back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
     # front_office: "http://localhost:3002"
     # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     

--- a/.config_Edge15_W10.yml
+++ b/.config_Edge15_W10.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,19 +74,19 @@ custom:
       username: user@example.com
   urls:
     # Local
-    front_office: "http://localhost:3000/registrations/start"
-    front_office_sign_in: "http:/localhost:3000/users/sign_in"
-    front_office_renewals: "http://localhost:3002"
-    front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
-    back_office: "http:/localhost:3000/agency_users/sign_in"
-    back_office_admin: "http:/localhost:3000/admins/sign_in"
+    old_front_end: "http://localhost:3000/registrations/start"
+    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_office: "http://localhost:3002"
+    front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
+    old_back_end: "http:/localhost:3000/agency_users/sign_in"
+    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # front_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # front_office_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # back_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # back_office_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
-    # front_office_renewals: "http://localhost:3002"
-    # front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
+    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_office: "http://localhost:3002"
+    # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     
 
 # If you are running Quke behind a proxy you can configure the proxy details

--- a/.config_Firefox58_OSX.yml
+++ b/.config_Firefox58_OSX.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,17 +74,17 @@ custom:
       username: user@example.com
   urls:
     # Local
-    old_front_end: "http://localhost:3000/registrations/start"
-    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_end: "http://localhost:3000/registrations/start"
+    front_end_sign_in: "http:/localhost:3000/users/sign_in"
     front_office: "http://localhost:3002"
     front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
-    old_back_end: "http:/localhost:3000/agency_users/sign_in"
-    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
+    back_end: "http:/localhost:3000/agency_users/sign_in"
+    back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
     # front_office: "http://localhost:3002"
     # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     

--- a/.config_Firefox58_OSX.yml
+++ b/.config_Firefox58_OSX.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,19 +74,19 @@ custom:
       username: user@example.com
   urls:
     # Local
-    front_office: "http://localhost:3000/registrations/start"
-    front_office_sign_in: "http:/localhost:3000/users/sign_in"
-    front_office_renewals: "http://localhost:3002"
-    front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
-    back_office: "http:/localhost:3000/agency_users/sign_in"
-    back_office_admin: "http:/localhost:3000/admins/sign_in"
+    old_front_end: "http://localhost:3000/registrations/start"
+    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_office: "http://localhost:3002"
+    front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
+    old_back_end: "http:/localhost:3000/agency_users/sign_in"
+    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # front_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # front_office_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # back_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # back_office_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
-    # front_office_renewals: "http://localhost:3002"
-    # front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
+    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_office: "http://localhost:3002"
+    # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     
 
 # If you are running Quke behind a proxy you can configure the proxy details

--- a/.config_Firefox59_OSX.yml
+++ b/.config_Firefox59_OSX.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,17 +74,17 @@ custom:
       username: user@example.com
   urls:
     # Local
-    old_front_end: "http://localhost:3000/registrations/start"
-    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_end: "http://localhost:3000/registrations/start"
+    front_end_sign_in: "http:/localhost:3000/users/sign_in"
     front_office: "http://localhost:3002"
     front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
-    old_back_end: "http:/localhost:3000/agency_users/sign_in"
-    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
+    back_end: "http:/localhost:3000/agency_users/sign_in"
+    back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
     # front_office: "http://localhost:3002"
     # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     

--- a/.config_Firefox59_OSX.yml
+++ b/.config_Firefox59_OSX.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,19 +74,19 @@ custom:
       username: user@example.com
   urls:
     # Local
-    front_office: "http://localhost:3000/registrations/start"
-    front_office_sign_in: "http:/localhost:3000/users/sign_in"
-    front_office_renewals: "http://localhost:3002"
-    front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
-    back_office: "http:/localhost:3000/agency_users/sign_in"
-    back_office_admin: "http:/localhost:3000/admins/sign_in"
+    old_front_end: "http://localhost:3000/registrations/start"
+    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_office: "http://localhost:3002"
+    front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
+    old_back_end: "http:/localhost:3000/agency_users/sign_in"
+    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # front_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # front_office_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # back_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # back_office_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
-    # front_office_renewals: "http://localhost:3002"
-    # front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
+    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_office: "http://localhost:3002"
+    # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     
 
 # If you are running Quke behind a proxy you can configure the proxy details

--- a/.config_Galaxy_Note_8.yml
+++ b/.config_Galaxy_Note_8.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,17 +74,17 @@ custom:
       username: user@example.com
   urls:
     # Local
-    old_front_end: "http://localhost:3000/registrations/start"
-    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_end: "http://localhost:3000/registrations/start"
+    front_end_sign_in: "http:/localhost:3000/users/sign_in"
     front_office: "http://localhost:3002"
     front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
-    old_back_end: "http:/localhost:3000/agency_users/sign_in"
-    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
+    back_end: "http:/localhost:3000/agency_users/sign_in"
+    back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
     # front_office: "http://localhost:3002"
     # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     

--- a/.config_Galaxy_Note_8.yml
+++ b/.config_Galaxy_Note_8.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,19 +74,19 @@ custom:
       username: user@example.com
   urls:
     # Local
-    front_office: "http://localhost:3000/registrations/start"
-    front_office_sign_in: "http:/localhost:3000/users/sign_in"
-    front_office_renewals: "http://localhost:3002"
-    front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
-    back_office: "http:/localhost:3000/agency_users/sign_in"
-    back_office_admin: "http:/localhost:3000/admins/sign_in"
+    old_front_end: "http://localhost:3000/registrations/start"
+    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_office: "http://localhost:3002"
+    front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
+    old_back_end: "http:/localhost:3000/agency_users/sign_in"
+    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # front_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # front_office_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # back_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # back_office_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
-    # front_office_renewals: "http://localhost:3002"
-    # front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
+    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_office: "http://localhost:3002"
+    # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     
 
 # If you are running Quke behind a proxy you can configure the proxy details

--- a/.config_Google_Pixel.yml
+++ b/.config_Google_Pixel.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,17 +74,17 @@ custom:
       username: user@example.com
   urls:
     # Local
-    old_front_end: "http://localhost:3000/registrations/start"
-    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_end: "http://localhost:3000/registrations/start"
+    front_end_sign_in: "http:/localhost:3000/users/sign_in"
     front_office: "http://localhost:3002"
     front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
-    old_back_end: "http:/localhost:3000/agency_users/sign_in"
-    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
+    back_end: "http:/localhost:3000/agency_users/sign_in"
+    back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
     # front_office: "http://localhost:3002"
     # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     

--- a/.config_Google_Pixel.yml
+++ b/.config_Google_Pixel.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,19 +74,19 @@ custom:
       username: user@example.com
   urls:
     # Local
-    front_office: "http://localhost:3000/registrations/start"
-    front_office_sign_in: "http:/localhost:3000/users/sign_in"
-    front_office_renewals: "http://localhost:3002"
-    front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
-    back_office: "http:/localhost:3000/agency_users/sign_in"
-    back_office_admin: "http:/localhost:3000/admins/sign_in"
+    old_front_end: "http://localhost:3000/registrations/start"
+    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_office: "http://localhost:3002"
+    front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
+    old_back_end: "http:/localhost:3000/agency_users/sign_in"
+    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # front_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # front_office_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # back_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # back_office_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
-    # front_office_renewals: "http://localhost:3002"
-    # front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
+    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_office: "http://localhost:3002"
+    # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     
 
 # If you are running Quke behind a proxy you can configure the proxy details

--- a/.config_Safari10_1_OSX.yml
+++ b/.config_Safari10_1_OSX.yml
@@ -57,7 +57,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -76,17 +76,17 @@ custom:
       username: user@example.com
   urls:
     # Local
-    old_front_end: "http://localhost/registrations/start"
-    old_front_end_sign_in: "http://localhost:3000/users/sign_in"
+    front_end: "http://localhost/registrations/start"
+    front_end_sign_in: "http://localhost:3000/users/sign_in"
     front_office: "http://localhost:3002"
     front_office_sign_in: "http://localhost:3002/users/sign_in"
-    old_back_end: "http:/localhost:3000/agency_users/sign_in"
-    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
+    back_end: "http:/localhost:3000/agency_users/sign_in"
+    back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
     # front_office: "http://localhost:3002"
     # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     

--- a/.config_Safari10_1_OSX.yml
+++ b/.config_Safari10_1_OSX.yml
@@ -57,7 +57,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -76,19 +76,19 @@ custom:
       username: user@example.com
   urls:
     # Local
-    front_office: "http://localhost/registrations/start"
-    front_office_sign_in: "http://localhost:3000/users/sign_in"
-    front_office_renewals: "http://localhost:3002"
-    front_office_renewals_sign_in: "http://localhost:3002/users/sign_in"
-    back_office: "http:/localhost:3000/agency_users/sign_in"
-    back_office_admin: "http:/localhost:3000/admins/sign_in"
+    old_front_end: "http://localhost/registrations/start"
+    old_front_end_sign_in: "http://localhost:3000/users/sign_in"
+    front_office: "http://localhost:3002"
+    front_office_sign_in: "http://localhost:3002/users/sign_in"
+    old_back_end: "http:/localhost:3000/agency_users/sign_in"
+    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # front_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # front_office_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # back_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # back_office_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
-    # front_office_renewals: "http://localhost:3002"
-    # front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
+    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_office: "http://localhost:3002"
+    # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     
 
 # If you are running Quke behind a proxy you can configure the proxy details

--- a/.config_Safari11_OSX.yml
+++ b/.config_Safari11_OSX.yml
@@ -56,7 +56,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -75,17 +75,17 @@ custom:
       username: user@example.com
   urls:
     # Local
-    old_front_end: "http://localhost:3000/registrations/start"
-    old_front_end_sign_in: "http://localhost:3000/users/sign_in"
+    front_end: "http://localhost:3000/registrations/start"
+    front_end_sign_in: "http://localhost:3000/users/sign_in"
     front_office: "http://localhost:3002"
     front_office_sign_in: "http://localhost:3002/users/sign_in"
-    old_back_end: "http:/localhost:3000/agency_users/sign_in"
-    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
+    back_end: "http:/localhost:3000/agency_users/sign_in"
+    back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
     # front_office: "http://localhost:3002"
     # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     

--- a/.config_Safari11_OSX.yml
+++ b/.config_Safari11_OSX.yml
@@ -56,7 +56,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -75,19 +75,19 @@ custom:
       username: user@example.com
   urls:
     # Local
-    front_office: "http://localhost:3000/registrations/start"
-    front_office_sign_in: "http://localhost:3000/users/sign_in"
-    front_office_renewals: "http://localhost:3002"
-    front_office_renewals_sign_in: "http://localhost:3002/users/sign_in"
-    back_office: "http:/localhost:3000/agency_users/sign_in"
-    back_office_admin: "http:/localhost:3000/admins/sign_in"
+    old_front_end: "http://localhost:3000/registrations/start"
+    old_front_end_sign_in: "http://localhost:3000/users/sign_in"
+    front_office: "http://localhost:3002"
+    front_office_sign_in: "http://localhost:3002/users/sign_in"
+    old_back_end: "http:/localhost:3000/agency_users/sign_in"
+    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # front_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # front_office_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # back_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # back_office_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
-    # front_office_renewals: "http://localhost:3002"
-    # front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
+    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_office: "http://localhost:3002"
+    # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     
 
 # If you are running Quke behind a proxy you can configure the proxy details

--- a/.config_Safari9_1_OSX.yml
+++ b/.config_Safari9_1_OSX.yml
@@ -56,7 +56,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -75,17 +75,17 @@ custom:
       username: user@example.com
   urls:
     # Local
-    old_front_end: "http://http://localhost:3000/registrations/start"
-    old_front_end_sign_in: "http://localhost:3000/users/sign_in"
+    front_end: "http://http://localhost:3000/registrations/start"
+    front_end_sign_in: "http://localhost:3000/users/sign_in"
     front_office: "http://localhost:3002"
     front_office_sign_in: "http://localhost:3002/users/sign_in"
-    old_back_end: "http:/localhost:3000/agency_users/sign_in"
-    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
+    back_end: "http:/localhost:3000/agency_users/sign_in"
+    back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
     # front_office: "http://localhost:3002"
     # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     

--- a/.config_Safari9_1_OSX.yml
+++ b/.config_Safari9_1_OSX.yml
@@ -56,7 +56,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -75,19 +75,19 @@ custom:
       username: user@example.com
   urls:
     # Local
-    front_office: "http://http://localhost:3000/registrations/start"
-    front_office_sign_in: "http://localhost:3000/users/sign_in"
-    front_office_renewals: "http://localhost:3002"
-    front_office_renewals_sign_in: "http://localhost:3002/users/sign_in"
-    back_office: "http:/localhost:3000/agency_users/sign_in"
-    back_office_admin: "http:/localhost:3000/admins/sign_in"
+    old_front_end: "http://http://localhost:3000/registrations/start"
+    old_front_end_sign_in: "http://localhost:3000/users/sign_in"
+    front_office: "http://localhost:3002"
+    front_office_sign_in: "http://localhost:3002/users/sign_in"
+    old_back_end: "http:/localhost:3000/agency_users/sign_in"
+    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # front_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # front_office_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # back_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # back_office_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
-    # front_office_renewals: "http://localhost:3002"
-    # front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
+    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_office: "http://localhost:3002"
+    # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     
 
 # If you are running Quke behind a proxy you can configure the proxy details

--- a/.config_chrome63_W7.yml
+++ b/.config_chrome63_W7.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,17 +74,17 @@ custom:
       username: user@example.com
   urls:
     # Local
-    old_front_end: "http://localhost:3000/registrations/start"
-    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_end: "http://localhost:3000/registrations/start"
+    front_end_sign_in: "http:/localhost:3000/users/sign_in"
     front_office: "http://localhost:3002"
     front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
-    old_back_end: "http:/localhost:3000/agency_users/sign_in"
-    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
+    back_end: "http:/localhost:3000/agency_users/sign_in"
+    back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
     # front_office: "http://localhost:3002"
     # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     

--- a/.config_chrome63_W7.yml
+++ b/.config_chrome63_W7.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,19 +74,19 @@ custom:
       username: user@example.com
   urls:
     # Local
-    front_office: "http://localhost:3000/registrations/start"
-    front_office_sign_in: "http:/localhost:3000/users/sign_in"
-    front_office_renewals: "http://localhost:3002"
-    front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
-    back_office: "http:/localhost:3000/agency_users/sign_in"
-    back_office_admin: "http:/localhost:3000/admins/sign_in"
+    old_front_end: "http://localhost:3000/registrations/start"
+    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_office: "http://localhost:3002"
+    front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
+    old_back_end: "http:/localhost:3000/agency_users/sign_in"
+    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # front_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # front_office_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # back_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # back_office_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
-    # front_office_renewals: "http://localhost:3002"
-    # front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
+    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_office: "http://localhost:3002"
+    # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     
 
 # If you are running Quke behind a proxy you can configure the proxy details

--- a/.config_edge16_W10.yml
+++ b/.config_edge16_W10.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,17 +74,17 @@ custom:
       username: user@example.com
   urls:
     # Local
-    old_front_end: "http://localhost:3000/registrations/start"
-    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_end: "http://localhost:3000/registrations/start"
+    front_end_sign_in: "http:/localhost:3000/users/sign_in"
     front_office: "http://localhost:3002"
     front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
-    old_back_end: "http:/localhost:3000/agency_users/sign_in"
-    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
+    back_end: "http:/localhost:3000/agency_users/sign_in"
+    back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
     # front_office: "http://localhost:3002"
     # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     

--- a/.config_edge16_W10.yml
+++ b/.config_edge16_W10.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,19 +74,19 @@ custom:
       username: user@example.com
   urls:
     # Local
-    front_office: "http://localhost:3000/registrations/start"
-    front_office_sign_in: "http:/localhost:3000/users/sign_in"
-    front_office_renewals: "http://localhost:3002"
-    front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
-    back_office: "http:/localhost:3000/agency_users/sign_in"
-    back_office_admin: "http:/localhost:3000/admins/sign_in"
+    old_front_end: "http://localhost:3000/registrations/start"
+    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_office: "http://localhost:3002"
+    front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
+    old_back_end: "http:/localhost:3000/agency_users/sign_in"
+    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # front_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # front_office_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # back_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # back_office_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
-    # front_office_renewals: "http://localhost:3002"
-    # front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
+    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_office: "http://localhost:3002"
+    # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     
 
 # If you are running Quke behind a proxy you can configure the proxy details

--- a/.config_firefox58_W8_1.yml
+++ b/.config_firefox58_W8_1.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,17 +74,17 @@ custom:
       username: user@example.com
   urls:
     # Local
-    old_front_end: "http://localhost:3000/registrations/start"
-    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_end: "http://localhost:3000/registrations/start"
+    front_end_sign_in: "http:/localhost:3000/users/sign_in"
     front_office: "http://localhost:3002"
     front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
-    old_back_end: "http:/localhost:3000/agency_users/sign_in"
-    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
+    back_end: "http:/localhost:3000/agency_users/sign_in"
+    back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
     # front_office: "http://localhost:3002"
     # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     

--- a/.config_firefox58_W8_1.yml
+++ b/.config_firefox58_W8_1.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,19 +74,19 @@ custom:
       username: user@example.com
   urls:
     # Local
-    front_office: "http://localhost:3000/registrations/start"
-    front_office_sign_in: "http:/localhost:3000/users/sign_in"
-    front_office_renewals: "http://localhost:3002"
-    front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
-    back_office: "http:/localhost:3000/agency_users/sign_in"
-    back_office_admin: "http:/localhost:3000/admins/sign_in"
+    old_front_end: "http://localhost:3000/registrations/start"
+    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_office: "http://localhost:3002"
+    front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
+    old_back_end: "http:/localhost:3000/agency_users/sign_in"
+    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # front_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # front_office_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # back_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # back_office_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
-    # front_office_renewals: "http://localhost:3002"
-    # front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
+    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_office: "http://localhost:3002"
+    # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     
 
 # If you are running Quke behind a proxy you can configure the proxy details

--- a/.config_firefox59_W10.yml
+++ b/.config_firefox59_W10.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,17 +74,17 @@ custom:
       username: user@example.com
   urls:
     # Local
-    old_front_end: "http://localhost:3000/registrations/start"
-    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_end: "http://localhost:3000/registrations/start"
+    front_end_sign_in: "http:/localhost:3000/users/sign_in"
     front_office: "http://localhost:3002"
     front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
-    old_back_end: "http:/localhost:3000/agency_users/sign_in"
-    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
+    back_end: "http:/localhost:3000/agency_users/sign_in"
+    back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
     # front_office: "http://localhost:3002"
     # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     

--- a/.config_firefox59_W10.yml
+++ b/.config_firefox59_W10.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,19 +74,19 @@ custom:
       username: user@example.com
   urls:
     # Local
-    front_office: "http://localhost:3000/registrations/start"
-    front_office_sign_in: "http:/localhost:3000/users/sign_in"
-    front_office_renewals: "http://localhost:3002"
-    front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
-    back_office: "http:/localhost:3000/agency_users/sign_in"
-    back_office_admin: "http:/localhost:3000/admins/sign_in"
+    old_front_end: "http://localhost:3000/registrations/start"
+    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_office: "http://localhost:3002"
+    front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
+    old_back_end: "http:/localhost:3000/agency_users/sign_in"
+    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # front_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # front_office_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # back_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # back_office_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
-    # front_office_renewals: "http://localhost:3002"
-    # front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
+    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_office: "http://localhost:3002"
+    # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     
 
 # If you are running Quke behind a proxy you can configure the proxy details

--- a/.config_iPhone7.yml
+++ b/.config_iPhone7.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,19 +74,19 @@ custom:
       username: user@example.com
   urls:
     # Local
-    front_office: "http://localhost:3000/registrations/start"
-    front_office_sign_in: "http:/localhost:3000/users/sign_in"
-    front_office_renewals: "http://localhost:3002"
-    front_office_renewals_sign_in: "http://localhost:3002/users/sign_in"
-    back_office: "http:/localhost:3000/agency_users/sign_in"
-    back_office_admin: "http:/localhost:3000/admins/sign_in"
+    old_front_end: "http://localhost:3000/registrations/start"
+    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_office: "http://localhost:3002"
+    front_office_sign_in: "http://localhost:3002/users/sign_in"
+    old_back_end: "http:/localhost:3000/agency_users/sign_in"
+    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # front_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # front_office_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # back_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # back_office_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
-    # front_office_renewals: "http://localhost:3002"
-    # front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
+    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_office: "http://localhost:3002"
+    # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     
 
 # If you are running Quke behind a proxy you can configure the proxy details

--- a/.config_iPhone7.yml
+++ b/.config_iPhone7.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,17 +74,17 @@ custom:
       username: user@example.com
   urls:
     # Local
-    old_front_end: "http://localhost:3000/registrations/start"
-    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_end: "http://localhost:3000/registrations/start"
+    front_end_sign_in: "http:/localhost:3000/users/sign_in"
     front_office: "http://localhost:3002"
     front_office_sign_in: "http://localhost:3002/users/sign_in"
-    old_back_end: "http:/localhost:3000/agency_users/sign_in"
-    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
+    back_end: "http:/localhost:3000/agency_users/sign_in"
+    back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
     # front_office: "http://localhost:3002"
     # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     

--- a/.config_iPhone_X.yml
+++ b/.config_iPhone_X.yml
@@ -56,7 +56,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -75,17 +75,17 @@ custom:
       username: user@example.com
   urls:
     # Local
-    old_front_end: "http://localhost:3000/registrations/start"
-    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_end: "http://localhost:3000/registrations/start"
+    front_end_sign_in: "http:/localhost:3000/users/sign_in"
     front_office: "http:/localhost:3002"
     front_office_sign_in: "http://localhost:3002/users/sign_in"
-    old_back_end: "http:/localhost:3000/agency_users/sign_in"
-    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
+    back_end: "http:/localhost:3000/agency_users/sign_in"
+    back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
     # front_office: "http:/localhost:3002"
     # front_office_sign_in: "http://localhost:3002/users/sign_in"
 

--- a/.config_iPhone_X.yml
+++ b/.config_iPhone_X.yml
@@ -56,7 +56,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -75,19 +75,19 @@ custom:
       username: user@example.com
   urls:
     # Local
-    front_office: "http://localhost:3000/registrations/start"
-    front_office_sign_in: "http:/localhost:3000/users/sign_in"
-    front_office_renewals: "http:/localhost:3002"
-    front_office_renewals_sign_in: "http://localhost:3002/users/sign_in"
-    back_office: "http:/localhost:3000/agency_users/sign_in"
-    back_office_admin: "http:/localhost:3000/admins/sign_in"
+    old_front_end: "http://localhost:3000/registrations/start"
+    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_office: "http:/localhost:3002"
+    front_office_sign_in: "http://localhost:3002/users/sign_in"
+    old_back_end: "http:/localhost:3000/agency_users/sign_in"
+    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # front_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # front_office_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # back_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # back_office_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
-    # front_office_renewals: "http:/localhost:3002"
-    # front_office_renewals_sign_in: "http://localhost:3002/users/sign_in"
+    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_office: "http:/localhost:3002"
+    # front_office_sign_in: "http://localhost:3002/users/sign_in"
 
 
 # If you are running Quke behind a proxy you can configure the proxy details

--- a/.config_ie11_W10.yml
+++ b/.config_ie11_W10.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,17 +74,17 @@ custom:
       username: user@example.com
   urls:
     # Local
-    old_front_end: "http://localhost:3000/registrations/start"
-    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_end: "http://localhost:3000/registrations/start"
+    front_end_sign_in: "http:/localhost:3000/users/sign_in"
     front_office: "http://localhost:3002"
     front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
-    old_back_end: "http:/localhost:3000/agency_users/sign_in"
-    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
+    back_end: "http:/localhost:3000/agency_users/sign_in"
+    back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
     # front_office: "http://localhost:3002"
     # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     

--- a/.config_ie11_W10.yml
+++ b/.config_ie11_W10.yml
@@ -55,7 +55,7 @@ javascript_errors: false
 #
 # Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
 # Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
-# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+# Quke::Quke.config.custom["urls"]["old_front_end"] # = "http://myservice.service.gov.uk"
 #
 # As long as what you add is valid YAML (check with a tool like
 # http://www.yamllint.com/) Quke will be able to pick it up and make it
@@ -74,19 +74,19 @@ custom:
       username: user@example.com
   urls:
     # Local
-    front_office: "http://localhost:3000/registrations/start"
-    front_office_sign_in: "http:/localhost:3000/users/sign_in"
-    front_office_renewals: "http://localhost:3002"
-    front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
-    back_office: "http:/localhost:3000/agency_users/sign_in"
-    back_office_admin: "http:/localhost:3000/admins/sign_in"
+    old_front_end: "http://localhost:3000/registrations/start"
+    old_front_end_sign_in: "http:/localhost:3000/users/sign_in"
+    front_office: "http://localhost:3002"
+    front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
+    old_back_end: "http:/localhost:3000/agency_users/sign_in"
+    old_back_end_admin: "http:/localhost:3000/admins/sign_in"
     # Sandbox
-    # front_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
-    # front_office_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
-    # back_office: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
-    # back_office_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
-    # front_office_renewals: "http://localhost:3002"
-    # front_office_renewals_sign_in: "http://localhost:3002/fo/users/sign_in"
+    # old_front_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/registrations/start"
+    # old_front_end_sign_in: "https://www.sandbox.wastecarriersregistration.service.gov.uk/users/sign_in"
+    # old_back_end: "https://www.sandbox.wastecarriersregistration.service.gov.uk/agency_users/sign_in"
+    # old_back_end_admin: "https://www.sandbox.wastecarriersregistration.service.gov.uk/admins/sign_in"
+    # front_office: "http://localhost:3002"
+    # front_office_sign_in: "http://localhost:3002/fo/users/sign_in"
     
 
 # If you are running Quke behind a proxy you can configure the proxy details

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ custom:
     front_office: "http://domainundertest.gov.uk/registrations/start"
     front_office_sign_in: "http://domainundertest.gov.uk/users/sign_in?locale=en"
     back_office: "http://domainundertest.gov.uk/agency_users/sign_in"
-    back_office_admin: "http://domainundertest.gov.uk/admins/sign_in"
+    back_office_sign_in: "http://domainundertest.gov.uk/admins/sign_in"
 
 ```
 

--- a/features/page_objects/back_office/new/dashboard_page.rb
+++ b/features/page_objects/back_office/new/dashboard_page.rb
@@ -1,7 +1,7 @@
 require_relative "sections/govuk_banner.rb"
 
 class DashboardPage < SitePrism::Page
-  set_url(Quke::Quke.config.custom["urls"]["back_office_renewals"])
+  set_url(Quke::Quke.config.custom["urls"]["back_office"])
 
   section(:govuk_banner, GovukBanner, GovukBanner::SELECTOR)
   element(:heading, ".heading-large")

--- a/features/page_objects/back_office/new/sign_in_page.rb
+++ b/features/page_objects/back_office/new/sign_in_page.rb
@@ -1,5 +1,5 @@
 class SignInPage < SitePrism::Page
-  set_url(Quke::Quke.config.custom["urls"]["back_office_renewals_sign_in"])
+  set_url(Quke::Quke.config.custom["urls"]["back_office_sign_in"])
 
   element(:email, "#user_email")
   element(:password, "#user_password")

--- a/features/page_objects/back_office/new/user_invite_page.rb
+++ b/features/page_objects/back_office/new/user_invite_page.rb
@@ -1,7 +1,7 @@
 require_relative "sections/govuk_banner.rb"
 
 class UserInvitePage < SitePrism::Page
-  set_url "#{Quke::Quke.config.custom['urls']['back_office_renewals']}/bo/users/invitation/new"
+  set_url "#{Quke::Quke.config.custom['urls']['back_office']}/users/invitation/new"
 
   section(:govuk_banner, GovukBanner, GovukBanner::SELECTOR)
 

--- a/features/page_objects/back_office/new/users_page.rb
+++ b/features/page_objects/back_office/new/users_page.rb
@@ -1,7 +1,7 @@
 require_relative "sections/govuk_banner.rb"
 
 class UsersPage < SitePrism::Page
-  set_url "#{Quke::Quke.config.custom['urls']['back_office_renewals']}/bo/users"
+  set_url "#{Quke::Quke.config.custom['urls']['back_office']}/users"
 
   section(:govuk_banner, GovukBanner, GovukBanner::SELECTOR)
 

--- a/features/page_objects/back_office/old/admin_sign_in_page.rb
+++ b/features/page_objects/back_office/old/admin_sign_in_page.rb
@@ -1,6 +1,6 @@
 class AdminSignInPage < SitePrism::Page
 
-  set_url(Quke::Quke.config.custom["urls"]["old_back_end_admin"])
+  set_url(Quke::Quke.config.custom["urls"]["back_end_admin"])
 
   element(:email, "#admin_email")
   element(:password, "#admin_password")

--- a/features/page_objects/back_office/old/admin_sign_in_page.rb
+++ b/features/page_objects/back_office/old/admin_sign_in_page.rb
@@ -1,6 +1,6 @@
 class AdminSignInPage < SitePrism::Page
 
-  set_url(Quke::Quke.config.custom["urls"]["backend_admin"])
+  set_url(Quke::Quke.config.custom["urls"]["old_back_end_admin"])
 
   element(:email, "#admin_email")
   element(:password, "#admin_password")

--- a/features/page_objects/back_office/old/agency_sign_in_page.rb
+++ b/features/page_objects/back_office/old/agency_sign_in_page.rb
@@ -1,6 +1,6 @@
 class AgencySignInPage < SitePrism::Page
 
-  set_url(Quke::Quke.config.custom["urls"]["back_office"])
+  set_url(Quke::Quke.config.custom["urls"]["old_back_end"])
 
   element(:email, "#agency_user_email")
   element(:password, "#agency_user_password")

--- a/features/page_objects/back_office/old/agency_sign_in_page.rb
+++ b/features/page_objects/back_office/old/agency_sign_in_page.rb
@@ -1,6 +1,6 @@
 class AgencySignInPage < SitePrism::Page
 
-  set_url(Quke::Quke.config.custom["urls"]["old_back_end"])
+  set_url(Quke::Quke.config.custom["urls"]["back_end"])
 
   element(:email, "#agency_user_email")
   element(:password, "#agency_user_password")

--- a/features/page_objects/front_office/registrations/old_start_page.rb
+++ b/features/page_objects/front_office/registrations/old_start_page.rb
@@ -1,6 +1,6 @@
 class OldStartPage < SitePrism::Page
 
-  set_url(Quke::Quke.config.custom["urls"]["old_front_end"])
+  set_url(Quke::Quke.config.custom["urls"]["front_end"])
 
   # Have you already started an application?
   element(:new_registration, "input[value='new']", visible: false)

--- a/features/page_objects/front_office/registrations/old_start_page.rb
+++ b/features/page_objects/front_office/registrations/old_start_page.rb
@@ -1,6 +1,6 @@
 class OldStartPage < SitePrism::Page
 
-  set_url(Quke::Quke.config.custom["urls"]["front_office"])
+  set_url(Quke::Quke.config.custom["urls"]["old_front_end"])
 
   # Have you already started an application?
   element(:new_registration, "input[value='new']", visible: false)

--- a/features/page_objects/front_office/registrations/start_page.rb
+++ b/features/page_objects/front_office/registrations/start_page.rb
@@ -1,5 +1,5 @@
 class StartPage < SitePrism::Page
-  set_url("#{Quke::Quke.config.custom['urls']['front_office_renewals']}/fo/start")
+  set_url("#{Quke::Quke.config.custom['urls']['front_office']}/start")
 
   element(:new_registration, "input[value='new']", visible: false)
   element(:renew_registration, "input[value='renew']", visible: false)

--- a/features/page_objects/front_office/registrations/waste_carrier_sign_in_page.rb
+++ b/features/page_objects/front_office/registrations/waste_carrier_sign_in_page.rb
@@ -2,7 +2,7 @@ class WasteCarrierSignInPage < SitePrism::Page
 
   # Sign in
 
-  set_url(Quke::Quke.config.custom["urls"]["front_office_sign_in"])
+  set_url(Quke::Quke.config.custom["urls"]["old_front_end_sign_in"])
 
   # Cannot simply use the CSS # id selector because there are 2 elements on the
   # page with this id; one a div the other an input

--- a/features/page_objects/front_office/registrations/waste_carrier_sign_in_page.rb
+++ b/features/page_objects/front_office/registrations/waste_carrier_sign_in_page.rb
@@ -2,7 +2,7 @@ class WasteCarrierSignInPage < SitePrism::Page
 
   # Sign in
 
-  set_url(Quke::Quke.config.custom["urls"]["old_front_end_sign_in"])
+  set_url(Quke::Quke.config.custom["urls"]["front_end_sign_in"])
 
   # Cannot simply use the CSS # id selector because there are 2 elements on the
   # page with this id; one a div the other an input

--- a/features/page_objects/front_office/renewals/waste_carriers_renewals_sign_in_page.rb
+++ b/features/page_objects/front_office/renewals/waste_carriers_renewals_sign_in_page.rb
@@ -1,8 +1,9 @@
 class WasteCarrierRenewalsSignInPage < SitePrism::Page
 
-  # Sign in
+  # Sign in for external users on new app.
+  # This page will become redundant when we remove accounts.
 
-  set_url(Quke::Quke.config.custom["urls"]["front_office_renewals_sign_in"])
+  set_url(Quke::Quke.config.custom["urls"]["front_office_sign_in"])
 
   # Cannot simply use the CSS # id selector because there are 2 elements on the
   # page with this id; one a div the other an input

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -86,7 +86,7 @@ Then(/^the registration does not have a status of "([^"]*)"$/) do |status|
 end
 
 Then(/^the registration status in the registration export is set to "([^"]*)"$/) do |status|
-  visit(Quke::Quke.config.custom["urls"]["back_end_dashboard"])
+  visit(Quke::Quke.config.custom["urls"]["old_back_end_dashboard"])
 
   # finds today's date and saves them for use in export from and to date
   time = Time.new

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -86,7 +86,7 @@ Then(/^the registration does not have a status of "([^"]*)"$/) do |status|
 end
 
 Then(/^the registration status in the registration export is set to "([^"]*)"$/) do |status|
-  visit(Quke::Quke.config.custom["urls"]["old_back_end_dashboard"])
+  visit(Quke::Quke.config.custom["urls"]["back_end_dashboard"])
 
   # finds today's date and saves them for use in export from and to date
   time = Time.new

--- a/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
@@ -224,7 +224,7 @@ Then(/^the expiry date should be three years from the previous expiry date$/) do
   # Adds three years to expiry date and then checks expiry date reported in registration details.
   # Need to convert this step to new app!
   @expected_expiry_date = @expiry_date_year_first.next_year(3)
-  visit(Quke::Quke.config.custom["urls"]["back_office"])
+  visit(Quke::Quke.config.custom["urls"]["old_back_end"])
   @back_app.registrations_page.search(search_input: @reg_number)
   actual_expiry_date = Date.parse(@back_app.registrations_page.search_results[0].expiry_date.text)
   expect(@expected_expiry_date).to eq(actual_expiry_date)
@@ -258,7 +258,7 @@ end
 
 When(/^I approve the conviction check$/) do
   @bo.dashboard_page.govuk_banner.conviction_checks_link.click
-  visit((Quke::Quke.config.custom["urls"]["back_office_renewals"]) + "/bo/transient-registrations/#{@reg_number}/convictions")
+  visit((Quke::Quke.config.custom["urls"]["back_office"]) + "/transient-registrations/#{@reg_number}/convictions")
 
   @bo.convictions_bo_details_page.approve_button.click
   @bo.convictions_decision_page.submit(conviction_reason: "ok")

--- a/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
@@ -224,7 +224,7 @@ Then(/^the expiry date should be three years from the previous expiry date$/) do
   # Adds three years to expiry date and then checks expiry date reported in registration details.
   # Need to convert this step to new app!
   @expected_expiry_date = @expiry_date_year_first.next_year(3)
-  visit(Quke::Quke.config.custom["urls"]["old_back_end"])
+  visit(Quke::Quke.config.custom["urls"]["back_end"])
   @back_app.registrations_page.search(search_input: @reg_number)
   actual_expiry_date = Date.parse(@back_app.registrations_page.search_results[0].expiry_date.text)
   expect(@expected_expiry_date).to eq(actual_expiry_date)

--- a/features/step_definitions/front_office/renewal_steps.rb
+++ b/features/step_definitions/front_office/renewal_steps.rb
@@ -400,7 +400,7 @@ end
 When(/^I try to renew anyway by guessing the renewal url for "([^"]*)"$/) do |reg_no|
   @renewals_app = RenewalsApp.new
   @journey = JourneyApp.new
-  renewal_url = Quke::Quke.config.custom["urls"]["front_office_renewals"] + "/fo/#{reg_no}/renew"
+  renewal_url = Quke::Quke.config.custom["urls"]["front_office"] + "/#{reg_no}/renew"
 
   visit(renewal_url)
 end

--- a/features/support/conviction_helpers.rb
+++ b/features/support/conviction_helpers.rb
@@ -56,9 +56,9 @@ end
 def go_to_conviction_for_reg(reg)
   if @resource_object == :renewal
     # Because it is difficult to find a unique link to the registration's conviction checks, visit the URL directly:
-    visit((Quke::Quke.config.custom["urls"]["back_office_renewals"]) + "/bo/transient-registrations/" + reg + "/convictions")
+    visit((Quke::Quke.config.custom["urls"]["back_office"]) + "/transient-registrations/" + reg + "/convictions")
   else # it's a registration
-    visit((Quke::Quke.config.custom["urls"]["back_office_renewals"]) + "/bo/registrations/" + reg + "/convictions")
+    visit((Quke::Quke.config.custom["urls"]["back_office"]) + "/registrations/" + reg + "/convictions")
   end
   expect(@bo.convictions_bo_details_page.heading).to have_text("Conviction information for " + reg)
 

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -12,11 +12,11 @@ def load_all_apps
 end
 
 def visit_registration_details_page(reg_identifier)
-  visit("#{Quke::Quke.config.custom['urls']['back_office_renewals']}/bo/registrations/#{reg_identifier}")
+  visit("#{Quke::Quke.config.custom['urls']['back_office']}/registrations/#{reg_identifier}")
 end
 
 def visit_renewal_details_page(reg_identifier)
-  visit("#{Quke::Quke.config.custom['urls']['back_office_renewals']}/bo/renewing-registrations/#{reg_identifier}")
+  visit("#{Quke::Quke.config.custom['urls']['back_office']}/renewing-registrations/#{reg_identifier}")
 end
 
 def sign_in_to_front_end_if_necessary(email)
@@ -38,7 +38,7 @@ def sign_in_to_back_office(user, force = true)
   # If force == true then this forces signout regardless of the user's type.
 
   # Check whether user is already logged in by visiting root page:
-  visit((Quke::Quke.config.custom["urls"]["back_office_renewals"]) + "/bo")
+  visit(Quke::Quke.config.custom["urls"]["back_office"])
 
   # Return if already logged in as that user.
   # This relies on the user property name in .config.yml being the same as the start of the user's email address:
@@ -59,7 +59,7 @@ end
 
 def sign_out_of_back_office
   # Check not already signed out
-  visit((Quke::Quke.config.custom["urls"]["back_office_renewals"]) + "/bo")
+  visit(Quke::Quke.config.custom["urls"]["back_office"])
   heading = @journey.standard_page.heading.text
 
   # Bypass if already logged out:


### PR DESCRIPTION
This PR refactors all URLs used in the service.

Old app URLs are now prefixed with `old_` and referred to as front / back end.
New app URLs are called front/back_office and now include `/fo` or `bo`.

Smoke tests and rubocop pass.