### PR TITLE
Add support to fetch finance urls directly

### DIFF
--- a/features/page_objects/journey/api_result_page.rb
+++ b/features/page_objects/journey/api_result_page.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "json"
+
+class ApiResultPage < SitePrism::Page
+  # This is a wrapper page around JSON API results
+
+  element(:json_data, "pre")
+
+  def extract_data
+    JSON.parse(json_data.text)
+  end
+end

--- a/features/step_definitions/back_office/upper_tier/finance_admin_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/finance_admin_steps.rb
@@ -1,9 +1,7 @@
 Given(/^an agency-refund-payment-user refunds the WorldPay payment$/) do
-
   sign_in_to_back_office("agency-refund-payment-user")
-  go_to_payments_page(@reg_number)
 
-  @bo.finance_payment_details_page.refund_button.click
+  visit_registration_refund_page(@reg_number)
   expect(@bo.finance_refund_select_page.heading).to have_text("Which payment do you want to refund?")
 
   # Use hidden text to identify correct refund link.

--- a/features/step_definitions/back_office/upper_tier/finance_payment_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/finance_payment_steps.rb
@@ -2,7 +2,7 @@ When(/^the registration's balance is (-?\d+)$/) do |balance|
   sign_in_to_back_office("agency-refund-payment-user")
 
   # Firstly, check the balance for that registration:
-  visit_registration_details_page(@reg_number)
+  visit_registration_finance_details_page(@reg_number)
   check_balance(balance)
 
   # Once confirmed, set the balance variable to that value for future steps
@@ -40,7 +40,7 @@ When(/^the transient renewal's balance is (-?\d+)$/) do |balance|
   # This step assumes that any back office user is already logged in
   # and the payment status is viewable for that renewal (it's been submitted)
 
-  visit_renewal_details_page(@reg_number)
+  visit_renewal_finance_details_page(@reg_number)
   check_balance(balance)
 
   # Once checked, set the balance variable to that value for future steps
@@ -49,7 +49,6 @@ end
 
 When(/^NCCC makes a payment of (\d+) by "([^"]*)"$/) do |amount, method|
   sign_in_as_appropriate_finance_user(method)
-  go_to_payments_page(@reg_number)
   enter_payment(amount, method)
   check_payment_confirmation_message(amount)
   @reg_balance -= amount
@@ -57,7 +56,6 @@ end
 
 When(/^NCCC pays the remaining balance by "([^"]*)"$/) do |method|
   sign_in_as_appropriate_finance_user(method)
-  go_to_payments_page(@reg_number)
   enter_payment(@reg_balance, method)
   check_payment_confirmation_message(@reg_balance)
   @reg_balance = 0

--- a/features/support/fetch_registration_data_helpers.rb
+++ b/features/support/fetch_registration_data_helpers.rb
@@ -1,35 +1,33 @@
 # Used for caching
-@@reg_identifier = nil
-@@data = nil
 
 def registration_id_for(reg_identifier)
-  fetch_registration_data_for(reg_identifier) unless reg_identifier == @@reg_identifier
+  fetch_registration_data_for(reg_identifier) unless reg_identifier == @fetch_reg_identifier_cache
 
-  @@data["_id"]
+  @fetch_data_cache["_id"]
 end
 
 def renewal_id_for(reg_identifier)
-  fetch_renewal_data_for(reg_identifier) unless reg_identifier == @@reg_identifier
+  fetch_renewal_data_for(reg_identifier) unless reg_identifier == @fetch_reg_identifier_cache
 
-  @@data["_id"]
+  @fetch_data_cache["_id"]
 end
 
 def fetch_registration_data_for(reg_identifier)
   # Sign in to back office unless already signed in
   sign_in_to_back_office("agency-refund-payment-user", false)
 
-  visit "#{Quke::Quke.config.custom["urls"]["back_office"]}/api/registrations/#{reg_identifier}"
+  visit "#{Quke::Quke.config.custom['urls']['back_office']}/api/registrations/#{reg_identifier}"
 
-  @@data = ApiResultPage.new.extract_data
-  @@reg_identifier = reg_identifier
+  @fetch_data_cache = ApiResultPage.new.extract_data
+  @fetch_reg_identifier_cache = reg_identifier
 end
 
 def fetch_renewal_data_for(reg_identifier)
   # Sign in to back office unless already signed in
   sign_in_to_back_office("agency-refund-payment-user", false)
 
-  visit "#{Quke::Quke.config.custom["urls"]["back_office"]}/api/renewals/#{reg_identifier}"
+  visit "#{Quke::Quke.config.custom['urls']['back_office']}/api/renewals/#{reg_identifier}"
 
-  @@data = ApiResultPage.new.extract_data
-  @@reg_identifier = reg_identifier
+  @fetch_data_cache = ApiResultPage.new.extract_data
+  @fetch_reg_identifier_cache = reg_identifier
 end

--- a/features/support/fetch_registration_data_helpers.rb
+++ b/features/support/fetch_registration_data_helpers.rb
@@ -1,5 +1,3 @@
-# Used for caching
-
 def registration_id_for(reg_identifier)
   fetch_registration_data_for(reg_identifier) unless reg_identifier == @fetch_reg_identifier_cache
 

--- a/features/support/fetch_registration_data_helpers.rb
+++ b/features/support/fetch_registration_data_helpers.rb
@@ -1,0 +1,35 @@
+# Used for caching
+@@reg_identifier = nil
+@@data = nil
+
+def registration_id_for(reg_identifier)
+  fetch_registration_data_for(reg_identifier) unless reg_identifier == @@reg_identifier
+
+  @@data["_id"]
+end
+
+def renewal_id_for(reg_identifier)
+  fetch_renewal_data_for(reg_identifier) unless reg_identifier == @@reg_identifier
+
+  @@data["_id"]
+end
+
+def fetch_registration_data_for(reg_identifier)
+  # Sign in to back office unless already signed in
+  sign_in_to_back_office("agency-refund-payment-user", false)
+
+  visit "#{Quke::Quke.config.custom["urls"]["back_office"]}/api/registrations/#{reg_identifier}"
+
+  @@data = ApiResultPage.new.extract_data
+  @@reg_identifier = reg_identifier
+end
+
+def fetch_renewal_data_for(reg_identifier)
+  # Sign in to back office unless already signed in
+  sign_in_to_back_office("agency-refund-payment-user", false)
+
+  visit "#{Quke::Quke.config.custom["urls"]["back_office"]}/api/renewals/#{reg_identifier}"
+
+  @@data = ApiResultPage.new.extract_data
+  @@reg_identifier = reg_identifier
+end

--- a/features/support/finance_helpers.rb
+++ b/features/support/finance_helpers.rb
@@ -26,8 +26,6 @@ def pay_by_cash(amount_in_pounds)
 end
 
 def check_balance(expected_balance)
-  @bo.registration_details_page.payment_details_link.click
-
   # Get the balance from the payment details page, assuming it is the last text on the page.
 
   # The regex searches for: any number of digits . two more digits newline Open Government Licence
@@ -57,7 +55,7 @@ def enter_payment(amount, method)
   # Amount can be a string or number.
   # List of method options is in finance_payment_method_page.rb
 
-  @bo.finance_payment_details_page.enter_payment_button.click
+  visit_registration_enter_payment_page(@reg_number)
   @bo.finance_payment_method_page.submit(choice: method.to_sym)
   expect(@bo.finance_payment_input_page).to have_amount
   expect(@bo.finance_payment_input_page.heading).to have_text("payment for " + @reg_number)

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -11,14 +11,6 @@ def load_all_apps
   @renewals_app = RenewalsApp.new
 end
 
-def visit_registration_details_page(reg_identifier)
-  visit("#{Quke::Quke.config.custom['urls']['back_office']}/registrations/#{reg_identifier}")
-end
-
-def visit_renewal_details_page(reg_identifier)
-  visit("#{Quke::Quke.config.custom['urls']['back_office']}/renewing-registrations/#{reg_identifier}")
-end
-
 def sign_in_to_front_end_if_necessary(email)
   @renewals_app = RenewalsApp.new
 

--- a/features/support/visit_url_helpers.rb
+++ b/features/support/visit_url_helpers.rb
@@ -1,0 +1,31 @@
+def visit_registration_finance_details_page(reg_number)
+  id = registration_id_for(reg_number)
+
+  visit "#{Quke::Quke.config.custom["urls"]["back_office"]}/resources/#{id}/finance-details"
+end
+
+def visit_renewal_finance_details_page(reg_number)
+  id = renewal_id_for(reg_number)
+
+  visit "#{Quke::Quke.config.custom["urls"]["back_office"]}/resources/#{id}/finance-details"
+end
+
+def visit_registration_enter_payment_page(reg_number)
+  id = renewal_id_for(reg_number)
+
+  visit "#{Quke::Quke.config.custom["urls"]["back_office"]}/resources/#{id}/payments"
+end
+
+def visit_registration_refund_page(reg_number)
+  id = renewal_id_for(reg_number)
+
+  visit "#{Quke::Quke.config.custom["urls"]["back_office"]}/resources/#{id}/refunds"
+end
+
+def visit_registration_details_page(reg_identifier)
+  visit("#{Quke::Quke.config.custom['urls']['back_office']}/registrations/#{reg_identifier}")
+end
+
+def visit_renewal_details_page(reg_identifier)
+  visit("#{Quke::Quke.config.custom['urls']['back_office']}/renewing-registrations/#{reg_identifier}")
+end

--- a/features/support/visit_url_helpers.rb
+++ b/features/support/visit_url_helpers.rb
@@ -1,25 +1,25 @@
 def visit_registration_finance_details_page(reg_number)
   id = registration_id_for(reg_number)
 
-  visit "#{Quke::Quke.config.custom["urls"]["back_office"]}/resources/#{id}/finance-details"
+  visit "#{Quke::Quke.config.custom['urls']['back_office']}/resources/#{id}/finance-details"
 end
 
 def visit_renewal_finance_details_page(reg_number)
   id = renewal_id_for(reg_number)
 
-  visit "#{Quke::Quke.config.custom["urls"]["back_office"]}/resources/#{id}/finance-details"
+  visit "#{Quke::Quke.config.custom['urls']['back_office']}/resources/#{id}/finance-details"
 end
 
 def visit_registration_enter_payment_page(reg_number)
   id = renewal_id_for(reg_number)
 
-  visit "#{Quke::Quke.config.custom["urls"]["back_office"]}/resources/#{id}/payments"
+  visit "#{Quke::Quke.config.custom['urls']['back_office']}/resources/#{id}/payments"
 end
 
 def visit_registration_refund_page(reg_number)
   id = renewal_id_for(reg_number)
 
-  visit "#{Quke::Quke.config.custom["urls"]["back_office"]}/resources/#{id}/refunds"
+  visit "#{Quke::Quke.config.custom['urls']['back_office']}/resources/#{id}/refunds"
 end
 
 def visit_registration_details_page(reg_identifier)


### PR DESCRIPTION
This implements a new helper that will store the ID of a registration in an object and will use it to visit finance pages directly.
It is implemented so that it can be called multiple times with the same registration id but will only visit and fetch the data once, then store and play those back to the user via cache class instance objects.