### PR TITLE
Refactor of finance admin feature

### DIFF
--- a/features/bo_new/finance/finance_admin.feature
+++ b/features/bo_new/finance/finance_admin.feature
@@ -52,6 +52,7 @@ Feature: Finance admin
         And NCCC makes a payment of 105 by "cash"
         And the transient renewal's balance is 10
        When a finance admin user adjusts the charge by -15
+        And the renewal is completed
        Then the registration's balance is -5
         And the registration has a status of "ACTIVE"
 

--- a/features/step_definitions/back_office/permissions_steps.rb
+++ b/features/step_definitions/back_office/permissions_steps.rb
@@ -39,7 +39,6 @@ Then(/^I have the correct permissions for an agency refund payment user$/) do
 
   # Check agency-refund-payment-user cannot write off more than 5 pounds:
   sign_in_to_back_office("finance-admin-user")
-  go_to_payments_page(@reg_number)
   adjust_charge(1, 999) # adjust charge by +1 pound, passing a dummy number for second argument
 
   # Check that write off button is no longer available:
@@ -49,7 +48,6 @@ Then(/^I have the correct permissions for an agency refund payment user$/) do
 
   # Set the balance back to 5 pounds for remaining tests
   sign_in_to_back_office("finance-admin-user")
-  go_to_payments_page(@reg_number)
   adjust_charge(-1, 999) # adjust charge by -1 pound, passing a dummy number for second argument
 end
 

--- a/features/step_definitions/back_office/upper_tier/finance_admin_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/finance_admin_steps.rb
@@ -1,7 +1,7 @@
 Given(/^an agency-refund-payment-user refunds the WorldPay payment$/) do
   sign_in_to_back_office("agency-refund-payment-user")
 
-  visit_registration_refund_page(@reg_number)
+  visit_refund_page(@reg_number)
   expect(@bo.finance_refund_select_page.heading).to have_text("Which payment do you want to refund?")
 
   # Use hidden text to identify correct refund link.
@@ -28,7 +28,6 @@ end
 Given(/^a finance admin user adjusts the charge by (-?\d+)$/) do |amount|
   # input is a positive or negative integer amount
   sign_in_to_back_office("finance-admin-user")
-  go_to_payments_page(@reg_number)
   random_number = rand(0..999_999) # to help identify transaction later
   amount = amount.to_i
   adjust_charge(amount, random_number)
@@ -41,7 +40,6 @@ end
 
 Given(/^(?:a|an) "([^"]*)" reverses the previous payment$/) do |user|
   sign_in_to_back_office(user)
-  go_to_payments_page(@reg_number)
   reverse_last_transaction
 
   expect(@bo.finance_payment_details_page.flash_message).to have_text("reversed successfully")

--- a/features/step_definitions/back_office/upper_tier/finance_payment_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/finance_payment_steps.rb
@@ -2,13 +2,17 @@ When(/^the registration's balance is (-?\d+)$/) do |balance|
   sign_in_to_back_office("agency-refund-payment-user")
 
   # Firstly, check the balance for that registration:
-  visit_registration_finance_details_page(@reg_number)
+  visit_finance_details_page(@reg_number)
   check_balance(balance)
 
   # Once confirmed, set the balance variable to that value for future steps
   @reg_balance = balance
 
   @resource_object = :registration if balance.zero? && @convictions == "no convictions"
+end
+
+When("the renewal is completed") do
+  @resource_object = :registration
 end
 
 When(/^the applicant chooses to pay for the registration by bank transfer ordering (\d+) copy (?:card|cards)$/) do |copy_card_number|
@@ -40,7 +44,7 @@ When(/^the transient renewal's balance is (-?\d+)$/) do |balance|
   # This step assumes that any back office user is already logged in
   # and the payment status is viewable for that renewal (it's been submitted)
 
-  visit_renewal_finance_details_page(@reg_number)
+  visit_finance_details_page(@reg_number)
   check_balance(balance)
 
   # Once checked, set the balance variable to that value for future steps

--- a/features/support/fetch_registration_data_helpers.rb
+++ b/features/support/fetch_registration_data_helpers.rb
@@ -1,13 +1,7 @@
 def registration_id_for(reg_identifier)
-  fetch_registration_data_for(reg_identifier) unless reg_identifier == @fetch_reg_identifier_cache
+  fetch_registration_data_for(reg_identifier) unless reg_identifier == @fetch_registration_identifier_cache
 
-  @fetch_data_cache["_id"]
-end
-
-def renewal_id_for(reg_identifier)
-  fetch_renewal_data_for(reg_identifier) unless reg_identifier == @fetch_reg_identifier_cache
-
-  @fetch_data_cache["_id"]
+  @fetch_registration_data_cache["_id"]
 end
 
 def fetch_registration_data_for(reg_identifier)
@@ -16,8 +10,14 @@ def fetch_registration_data_for(reg_identifier)
 
   visit "#{Quke::Quke.config.custom['urls']['back_office']}/api/registrations/#{reg_identifier}"
 
-  @fetch_data_cache = ApiResultPage.new.extract_data
-  @fetch_reg_identifier_cache = reg_identifier
+  @fetch_registration_data_cache = ApiResultPage.new.extract_data
+  @fetch_registration_identifier_cache = reg_identifier
+end
+
+def renewal_id_for(reg_identifier)
+  fetch_renewal_data_for(reg_identifier) unless reg_identifier == @fetch_renewal_identifier_cache
+
+  @fetch_renewal_data_cache["_id"]
 end
 
 def fetch_renewal_data_for(reg_identifier)
@@ -26,6 +26,6 @@ def fetch_renewal_data_for(reg_identifier)
 
   visit "#{Quke::Quke.config.custom['urls']['back_office']}/api/renewals/#{reg_identifier}"
 
-  @fetch_data_cache = ApiResultPage.new.extract_data
-  @fetch_reg_identifier_cache = reg_identifier
+  @fetch_renewal_data_cache = ApiResultPage.new.extract_data
+  @fetch_renewal_identifier_cache = reg_identifier
 end

--- a/features/support/finance_helpers.rb
+++ b/features/support/finance_helpers.rb
@@ -55,7 +55,8 @@ def enter_payment(amount, method)
   # Amount can be a string or number.
   # List of method options is in finance_payment_method_page.rb
 
-  visit_registration_enter_payment_page(@reg_number)
+  visit_enter_payment_page(@reg_number)
+
   @bo.finance_payment_method_page.submit(choice: method.to_sym)
   expect(@bo.finance_payment_input_page).to have_amount
   expect(@bo.finance_payment_input_page.heading).to have_text("payment for " + @reg_number)
@@ -76,7 +77,7 @@ end
 
 def adjust_charge(amount, random_number)
   # Start from payments page and add a positive or negative charge
-  @bo.finance_payment_details_page.charge_adjust_button.click
+  visit_charge_adjust_page(@reg_number)
   expect(@bo.finance_charge_adjust_select_page.heading).to have_text("Make a charge adjustment for " + @reg_number)
   submit_option = amount >= 0 ? :positive : :negative
   @bo.finance_charge_adjust_select_page.submit(choice: submit_option)
@@ -92,7 +93,7 @@ end
 
 def reverse_last_transaction
   # Start from payments page and reverse the last transaction available to that user (according to their permissions)
-  @bo.finance_payment_details_page.reverse_payment_button.click
+  visit_reverse_payment_page(@reg_number)
   expect(@bo.finance_reversal_select_page.heading).to have_text("Which payment do you want to reverse?")
   @bo.finance_reversal_select_page.reverse_links.last.click
   expect(@bo.finance_reversal_input_page.heading).to have_text("Reverse a payment for " + @reg_number)

--- a/features/support/visit_url_helpers.rb
+++ b/features/support/visit_url_helpers.rb
@@ -1,23 +1,29 @@
-def visit_registration_finance_details_page(reg_number)
-  id = registration_id_for(reg_number)
+def visit_charge_adjust_page(reg_number)
+  id = @resource_object == :renewal ? renewal_id_for(reg_number) : registration_id_for(reg_number)
+
+  visit "#{Quke::Quke.config.custom['urls']['back_office']}/resources/#{id}/payments/charge-adjusts"
+end
+
+def visit_reverse_payment_page(reg_number)
+  id = @resource_object == :renewal ? renewal_id_for(reg_number) : registration_id_for(reg_number)
+
+  visit "#{Quke::Quke.config.custom['urls']['back_office']}/resources/#{id}/reversals"
+end
+
+def visit_finance_details_page(reg_number)
+  id = @resource_object == :renewal ? renewal_id_for(reg_number) : registration_id_for(reg_number)
 
   visit "#{Quke::Quke.config.custom['urls']['back_office']}/resources/#{id}/finance-details"
 end
 
-def visit_renewal_finance_details_page(reg_number)
-  id = renewal_id_for(reg_number)
-
-  visit "#{Quke::Quke.config.custom['urls']['back_office']}/resources/#{id}/finance-details"
-end
-
-def visit_registration_enter_payment_page(reg_number)
-  id = renewal_id_for(reg_number)
+def visit_enter_payment_page(reg_number)
+  id = @resource_object == :renewal ? renewal_id_for(reg_number) : registration_id_for(reg_number)
 
   visit "#{Quke::Quke.config.custom['urls']['back_office']}/resources/#{id}/payments"
 end
 
-def visit_registration_refund_page(reg_number)
-  id = renewal_id_for(reg_number)
+def visit_refund_page(reg_number)
+  id = @resource_object == :renewal ? renewal_id_for(reg_number) : registration_id_for(reg_number)
 
   visit "#{Quke::Quke.config.custom['urls']['back_office']}/resources/#{id}/refunds"
 end


### PR DESCRIPTION
This implement more steps using the direct visit of finance page. It also introduce a new step to tell the test suite that a renewal is completed and now operations have to happen on a registration. It also fixes some bugs introduced in the previous PR to deal with fetching registration VS renewal ids from the API