### PR TITLE
Remove unused tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ We are gradually moving functionality from "old" code to "new" code. For example
 bundle exec quke --tags @fo_new
 ```
 
-You can create [multiple config files](https://github.com/DEFRA/quke#multiple-configs), for example you may wish to have one setup for running against **Chrome**, and another to run against a different environment. You can tell **Quke** which config file to use by adding an environment variable argument to the command.
+To switch environments, update or comment out the relevant set of URLs from the current config file.
+
+You can also create [multiple config files](https://github.com/DEFRA/quke#multiple-configs), for example you may wish to have one setup for running against **Chrome**, and another to run against a different environment. You can tell **Quke** which config file to use by adding an environment variable argument to the command.
 
 ```bash
 QUKE_CONFIG='chrome.config.yml' bundle exec quke

--- a/features/bo_new/dashboard/convictions.feature
+++ b/features/bo_new/dashboard/convictions.feature
@@ -1,4 +1,4 @@
-@bo_new @upper_tier @convictions @smoke @bo_reg
+@bo_new @convictions @smoke @bo_reg
 Feature: Conviction checks during upper tier waste carrier registrations
   As a waste carrier administrator
   I want to check whether any known companies or individuals have any previous waste convictions

--- a/features/bo_new/dashboard/edit.feature
+++ b/features/bo_new/dashboard/edit.feature
@@ -1,4 +1,4 @@
-@bo_new @upper_tier @bo_dashboard @smoke
+@bo_new @bo_dashboard @smoke
 Feature: NCCC agent edits registration from back office
   As an NCCC agent
   I want to edit the details of a registration

--- a/features/bo_new/dashboard/manage_users.feature
+++ b/features/bo_new/dashboard/manage_users.feature
@@ -1,4 +1,4 @@
-@bo_new @upper_tier @bo_dashboard
+@bo_new @bo_dashboard
 Feature: [RUBY-759] Manage users
   As a super user
   I want to amend EA user privileges

--- a/features/bo_new/dashboard/order_cards.feature
+++ b/features/bo_new/dashboard/order_cards.feature
@@ -1,4 +1,4 @@
-@bo_new @upper_tier @bo_dashboard
+@bo_new @bo_dashboard
 Feature: [RUBY-767] NCCC agent orders registration cards from back office
   As an NCCC agent
   I want to order registration cards

--- a/features/bo_new/dashboard/permissions.feature
+++ b/features/bo_new/dashboard/permissions.feature
@@ -1,4 +1,4 @@
-@bo_new @upper_tier @bo_dashboard @smoke
+@bo_new @bo_dashboard @smoke
 Feature: Check back office permissions
   As a system administrator
   I want to ensure users can only access what they need to

--- a/features/bo_new/dashboard/revert_to_payment_summary.feature
+++ b/features/bo_new/dashboard/revert_to_payment_summary.feature
@@ -1,4 +1,4 @@
-@bo_new @upper_tier @bo_dashboard
+@bo_new @bo_dashboard
 Feature: NCCC agent unblocks a registration from back office
   As an NCCC agent
   I want to unblock a registration using a back office function

--- a/features/bo_new/dashboard/view_details.feature
+++ b/features/bo_new/dashboard/view_details.feature
@@ -1,4 +1,4 @@
-@bo_new @upper_tier @bo_dashboard @smoke @minismoke
+@bo_new @bo_dashboard @smoke @minismoke
 Feature: NCCC agent views registrations from back office
   As an NCCC agent
   I want to view registration and renewal details on one service

--- a/features/bo_new/finance/finance_admin.feature
+++ b/features/bo_new/finance/finance_admin.feature
@@ -1,4 +1,4 @@
-@bo_new @upper_tier @finance
+@bo_new @finance
 
 Feature: Finance admin
   As a user with finance privilieges

--- a/features/bo_new/finance/registration_payments.feature
+++ b/features/bo_new/finance/registration_payments.feature
@@ -1,4 +1,4 @@
-@bo_new @upper_tier @finance
+@bo_new @finance
 
 Feature: [RUBY-826] Pay for registrations
   As a user with finance privilieges

--- a/features/bo_new/finance/renewal_payments.feature
+++ b/features/bo_new/finance/renewal_payments.feature
@@ -1,4 +1,4 @@
-@bo_new @upper_tier @finance
+@bo_new @finance
 Feature: Recording of a non worldpay renewal payment and negative conviction check marks the registration renewal as completed.
   As an administrator of the Waste Carriers service
   I need to be able to record payments and conviction check results

--- a/features/bo_new/renewals/assisted_digital_renewal.feature
+++ b/features/bo_new/renewals/assisted_digital_renewal.feature
@@ -1,4 +1,4 @@
-@bo_new @upper_tier @bo_renew @renewal
+@bo_new @bo_renew @renewal
 
 Feature: Assisted digital renewal of an upper tier public body
   As a carrier of commercial waste

--- a/features/bo_new/renewals/incomplete_registration_completed_with_assistance.feature
+++ b/features/bo_new/renewals/incomplete_registration_completed_with_assistance.feature
@@ -1,4 +1,4 @@
-@bo_new @upper_tier @bo_renew @renewal
+@bo_new @bo_renew @renewal
 
 Feature: Incomplete renewal of an upper tier public body completed by NCCC
   As a carrier of commerical waste

--- a/features/bo_old/registrations/lower_ad_registration.feature
+++ b/features/bo_old/registrations/lower_ad_registration.feature
@@ -1,4 +1,4 @@
-@bo_old @lower_tier @ad @smoke @bo_reg
+@bo_old @smoke @bo_reg
 Feature: Assisted digital lower tier registrations
   As a carrier of domestic waste
   I want assistance with my waste carrier registration from the Environment Agency

--- a/features/bo_old/registrations/upper_ad_ltd_registration.feature
+++ b/features/bo_old/registrations/upper_ad_ltd_registration.feature
@@ -1,4 +1,4 @@
-@bo_old @upper_tier @bo_reg
+@bo_old @bo_reg
 Feature: Assisted digital registration of an upper tier Limited company
   As a carrier of commerical waste
   I want assistance with my waste carrier registration from the Environment Agency

--- a/features/bo_old/registrations/upper_ad_partnership_registration.feature
+++ b/features/bo_old/registrations/upper_ad_partnership_registration.feature
@@ -1,4 +1,4 @@
-@bo_old @upper_tier @bo_reg
+@bo_old @bo_reg
 Feature: Assisted digital registration of an upper tier partnership
   As a carrier of commerical waste
   I want assistance with my waste carrier registration from the Environment Agency

--- a/features/bo_old/registrations/upper_ad_public_body_registration.feature
+++ b/features/bo_old/registrations/upper_ad_public_body_registration.feature
@@ -1,4 +1,4 @@
-@bo_old @upper_tier @bo_reg
+@bo_old @bo_reg
 Feature: Assisted digital registration of an upper tier public body
   As a carrier of commerical waste
   I want assistance with my waste carrier registration from the Environment Agency

--- a/features/bo_old/registrations/upper_ad_sole_trader_registration.feature
+++ b/features/bo_old/registrations/upper_ad_sole_trader_registration.feature
@@ -1,4 +1,4 @@
-@bo_old @upper_tier @bo_reg
+@bo_old @bo_reg
 Feature: Assisted digital registration of an upper tier sole trader
   As a carrier of commerical waste
   I want assistance with my waste carrier registration from the Environment Agency

--- a/features/fo_new/dashboard/view_certificate.feature
+++ b/features/fo_new/dashboard/view_certificate.feature
@@ -1,4 +1,4 @@
-@fo_new @upper_tier @fo_dashboard
+@fo_new @fo_dashboard
 Feature: Waste carrier views certificate from user registrations dashboard
   As a carrier of commercial waste
   I want to be able to view my registration certificate

--- a/features/fo_new/new_registration/lower_tier.feature
+++ b/features/fo_new/new_registration/lower_tier.feature
@@ -1,4 +1,4 @@
-@fo_new @lower_tier @fo_reg @smoke
+@fo_new @fo_reg @smoke
 Feature: A new user registers as a lower tier waste carrier
   As a carrier of commercial waste
   I want to register for a lower tier licence

--- a/features/fo_new/new_registration/upper_tier.feature
+++ b/features/fo_new/new_registration/upper_tier.feature
@@ -1,12 +1,12 @@
-@fo_new @lower_tier @fo_reg @smoke @minismoke
+@fo_new @fo_reg @smoke @minismoke
 Feature: A new user registers as an upper tier waste carrier
   As a carrier of commercial waste
   I want to register for an upper tier licence
   So I can be compliant with the law
 
-  Scenario: A sole trader registers as a lower tier waste carrier and pays via Worldpay
+  Scenario: A sole trader registers as an upper tier waste carrier and pays via Worldpay
     Given I want to register as an upper tier carrier
-    When I start a new registration journey in "England" as a "soleTrader"
+     When I start a new registration journey in "England" as a "soleTrader"
       And I complete my registration
       And I pay by card
-    Then I am notified that my registration has been successful
+     Then I am notified that my registration has been successful

--- a/features/fo_new/renewals/payments.feature
+++ b/features/fo_new/renewals/payments.feature
@@ -1,4 +1,4 @@
-@fo_new @upper_tier @fo_renewal @renewal
+@fo_new @fo_renewal @renewal
 Feature: Registered waste carrier pays for their renewal
   As a carrier of commercial waste
   I want to be able to pay the relevant charge for my renewal

--- a/features/fo_new/renewals/renewal_changes.feature
+++ b/features/fo_new/renewals/renewal_changes.feature
@@ -1,4 +1,4 @@
-@fo_new @upper_tier @fo_renewal @renewal
+@fo_new @fo_renewal @renewal
 Feature: Registered waste carrier chooses to renew their registration from start page
   As a carrier of commercial waste
   I want to change my registration details when I renew my waste carriers licence with the Environment Agency

--- a/features/fo_new/renewals/renewal_convictions_checks.feature
+++ b/features/fo_new/renewals/renewal_convictions_checks.feature
@@ -1,4 +1,4 @@
-@fo_new @upper_tier @fo_renewal @renewal @convictions
+@fo_new @fo_renewal @renewal @convictions
 Feature: Registered waste carrier declares conviction during renewal
   As a member of the waste carriers team in NCCC
   I want to be informed of any potential matches with the Environment Agency's convictions database

--- a/features/fo_new/renewals/renewals.feature
+++ b/features/fo_new/renewals/renewals.feature
@@ -1,4 +1,4 @@
-@fo_new @upper_tier @fo_renewal @renewal
+@fo_new @fo_renewal @renewal
 Feature: Registered waste carrier chooses to renew their registration from registration search
   As a carrier of commercial waste
   I want to renew my waste carriers licence with the Environment Agency

--- a/features/fo_new/renewals/renewals_from_user_registrations_page.feature
+++ b/features/fo_new/renewals/renewals_from_user_registrations_page.feature
@@ -1,4 +1,4 @@
-@fo_new @upper_tier @fo_renewal @renewal @fo_dashboard
+@fo_new @fo_renewal @renewal @fo_dashboard
 Feature: Registered waste carrier chooses to renew their registration from registrations account page
   As a carrier of commercial waste
   I want to renew my waste carriers licence with the Environment Agency

--- a/features/fo_old/lower_registration.feature
+++ b/features/fo_old/lower_registration.feature
@@ -1,4 +1,4 @@
-@fo_old @lower_tier @fo_reg @email
+@fo_old @fo_reg @email
 Feature: New lower tier registrations
   As a carrier of domestic waste
   I want to register my company with the Environment Agency

--- a/features/fo_old/upper_limited_company_registration.feature
+++ b/features/fo_old/upper_limited_company_registration.feature
@@ -1,4 +1,4 @@
-@fo_old @upper_tier @fo_reg
+@fo_old @fo_reg
 Feature: Limited company applies for new upper tier registration
   As a carrier of commercial waste
   I want to register my company with the Environment Agency

--- a/features/fo_old/upper_partnership_registration.feature
+++ b/features/fo_old/upper_partnership_registration.feature
@@ -1,4 +1,4 @@
-@fo_old @upper_tier
+@fo_old
 Feature: Partnership applies for new upper tier registration
   As a carrier of commercial waste
   I want to register my partnership with the Environment Agency

--- a/features/fo_old/upper_public_body_registration.feature
+++ b/features/fo_old/upper_public_body_registration.feature
@@ -1,4 +1,4 @@
-@fo_old @upper_tier
+@fo_old
 Feature: Public body applies for new upper tier registration
   As a carrier of commercial waste
   I want to register my public body with the Environment Agency

--- a/features/fo_old/upper_sole_trader_registration.feature
+++ b/features/fo_old/upper_sole_trader_registration.feature
@@ -1,4 +1,4 @@
-@fo_old @upper_tier
+@fo_old
 Feature: Sole trader applies for new upper tier registration
   As a carrier of commercial waste
   I want to register my sole trader business with the Environment Agency

--- a/recycle_bin/fo/dashboard/upper_tier_edit_charges.feature
+++ b/recycle_bin/fo/dashboard/upper_tier_edit_charges.feature
@@ -1,4 +1,4 @@
-@fo_new @upper_tier @fo_dashboard
+@fo_new @fo_dashboard
 Feature: Upper tier registration edit charges
   As a carrier of commercial waste
   I want to be able to change my registration details


### PR DESCRIPTION
This PR removed the @upper_tier and @lower_tier tags, which are not currently being used, and corrects a wording issue where one scenario was being incorrectly identified as lower tier.