### PR TITLE
Remove need for database seeds via rake tasks

### DIFF
--- a/features/bo_new/dashboard/cease_and_revoke.feature
+++ b/features/bo_new/dashboard/cease_and_revoke.feature
@@ -1,5 +1,4 @@
 @bo_new @bo_dashboard
-# WARNING: This will only work once, locally, between database resets and vagrant reloads
 
 Feature: Cease and revoke registered waste carriers
 As an agency user
@@ -10,14 +9,11 @@ Background:
 	Given I sign into the back office as "agency-refund-payment-user"
 
   Scenario: Agency user can cease upper tier waste carrier licence
-    Given I have a registration "CBDU106"
-     When the registration is ceased
- 		 Then the registration has a status of "INACTIVE"
+    Given I have an active registration
+    When the registration is ceased
+    Then the registration has a status of "INACTIVE"
 
   Scenario: Agency user can revoke upper tier waste carrier licence
-    Given I have a registration "CBDU111"
-     When the registration is revoked
-		 Then the registration has a status of "REVOKED"
-
-		Given an Environment Agency user has signed in to the backend
-		 Then the registration status in the registration export is set to "REVOKED"
+    Given I have an active registration
+    When the registration is revoked
+    Then the registration has a status of "REVOKED"

--- a/features/bo_new/dashboard/order_cards.feature
+++ b/features/bo_new/dashboard/order_cards.feature
@@ -9,14 +9,16 @@ Background:
 
 @smoke
 Scenario: NCCC user orders one card by bank card
-  When an agency user orders "1" registration card for "CBDU208"
+  Given I have an active registration
+  When an agency user orders "1" registration card
    And the agency user pays for the card by bank card
   Then the card order is confirmed with cleared payment
    And the registration's balance is 0
    And the carrier receives an email saying their card order is being printed
 
 Scenario: NCCC user orders 3 cards by bank transfer
-  When an agency user orders "3" registration cards for "CBDU208"
+  Given I have an active registration
+  When an agency user orders "3" registration cards
    And the agency user chooses to pay for the card by bank transfer
   Then the card order is confirmed awaiting payment
    And the registration has a status of "PAYMENT NEEDED"

--- a/features/bo_new/dashboard/transfer.feature
+++ b/features/bo_new/dashboard/transfer.feature
@@ -5,7 +5,8 @@ I need to be able to change the account linked to a registration
 So that users can continue to maintain registrations even if their details change
 
   Scenario: Change the account where user has just one registration
-    Given I sign into the back office as "agency-user"
-      And I choose to transfer ownership of "CBDU234" to another user
+    Given I create a new registration as "another-user@example.com"
+      And I sign into the back office as "agency-user"
+      And I choose to transfer ownership of the registration to another user
      When I change the account email to "user@example.com"
      Then I see a confirmation the change has been made

--- a/features/bo_new/finance/renewal_payments.feature
+++ b/features/bo_new/finance/renewal_payments.feature
@@ -8,22 +8,24 @@ Feature: Recording of a non worldpay renewal payment and negative conviction che
 
   Scenario: Renewal paid for by bank transfer is marked as complete
       Given an Environment Agency user has signed in to the backend
-        And registration "CBDU205" has an unsubmitted renewal
+        And I have an active registration
+        And the registration has an unsubmitted renewal
         And I cannot access payments until the bank transfer option is selected
         And the transient renewal's balance is 105
 
-       When I search for "CBDU205" pending payment
+       When I search for the renewal pending payment
         And I mark the renewal payment as received
        Then the expiry date should be three years from the previous expiry date
         And the registration's balance is 0
 
   Scenario: Renewal paid for by bank transfer but with a conviction flag is still pending conviction check sign off
       Given an Environment Agency user has signed in to the backend
-        And registration "CBDU207" has an unsubmitted renewal
+        And I have an active registration with a company number of "01649776"
+        And the registration has an unsubmitted renewal
         And I cannot access payments until the bank transfer option is selected
         And the transient renewal's balance is 105
 
-       When I search for "CBDU207" pending payment
+       When I search for the renewal pending payment
         And I mark the renewal payment as received
        Then the registration has a status of "CONVICTIONS"
         And the registration's balance is 0

--- a/features/bo_new/renewals/assisted_digital_renewal.feature
+++ b/features/bo_new/renewals/assisted_digital_renewal.feature
@@ -9,13 +9,13 @@ Background:
   Given an Environment Agency user has signed in to the backend
 
 Scenario: Public body has their upper tier registration renewed by NCCC
-  Given I choose to renew "CBDU230"
+  Given I have a new registration for a "localAuthority" business
     And I sign into the back office as "agency-user"
    When I renew the local authority registration
    Then the renewal is complete
 
 Scenario: Limited company has their upper tier registration renewed by NCCC
-  Given I choose to renew "CBDU231"
+  Given I have a new registration for a "limitedCompany" business
     And I sign into the back office as "agency-user"
    When I renew the limited company registration
    Then the renewal is complete

--- a/features/bo_new/renewals/incomplete_registration_completed_with_assistance.feature
+++ b/features/bo_new/renewals/incomplete_registration_completed_with_assistance.feature
@@ -6,7 +6,8 @@ Feature: Incomplete renewal of an upper tier public body completed by NCCC
   So I can complete my regisration and I am compliant with the law
 
 Scenario: Public body has their upper tier registration renewed by NCCC
-  Given "CBDU229" has been partially renewed by the account holder
+  Given I have a new registration for a "localAuthority" business
+    And the registration has been partially renewed by the account holder
     And I sign into the back office as "agency-user"
-   When I complete the renewal "CBDU229" for the account holder
+   When I complete the renewal for the account holder
    Then the renewal is complete

--- a/features/seeds/fixtures/charity_complete_active_registration.json
+++ b/features/seeds/fixtures/charity_complete_active_registration.json
@@ -49,7 +49,6 @@
   "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
-  "regIdentifier": "CBDU228",
   "metaData": {
     "dateRegistered" : "2018-05-14T10:38:17.311Z",
     "lastModified" : "2018-05-14T10:38:22.692Z",

--- a/features/seeds/fixtures/limitedLiabilityPartnership_complete_active_registration.json
+++ b/features/seeds/fixtures/limitedLiabilityPartnership_complete_active_registration.json
@@ -62,7 +62,6 @@
   "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
-  "regIdentifier": "CBDU227",
   "metaData": {
     "dateRegistered" : "2018-05-14T10:38:17.311Z",
     "anotherString" : "userDetailAddedAtRegistration",

--- a/features/seeds/fixtures/localAuthority_complete_active_registration.json
+++ b/features/seeds/fixtures/localAuthority_complete_active_registration.json
@@ -1,11 +1,11 @@
 {
   "tier": "UPPER",
   "registrationType": "carrier_broker_dealer",
-  "businessType": "soleTrader",
+  "businessType": "localAuthority",
   "otherBusinesses": "yes",
   "isMainService": "yes",
   "onlyAMF": "no",
-  "companyName": "Sole Trader Seed",
+  "companyName": "LocalAuthority Seed",
   "firstName": "Test",
   "lastName": "User",
   "phoneNumber": "01234 567890",
@@ -51,6 +51,7 @@
   "declaration": 1,
   "metaData": {
     "dateRegistered" : "2018-05-14T10:38:17.311Z",
+    "anotherString" : "userDetailAddedAtRegistration",
     "lastModified" : "2018-05-14T10:38:22.692Z",
     "dateActivated" : "2018-05-14T10:38:22.692Z",
     "status": "ACTIVE",

--- a/features/seeds/fixtures/partnership_complete_active_registration.json
+++ b/features/seeds/fixtures/partnership_complete_active_registration.json
@@ -61,7 +61,6 @@
   "accountEmail": "user@example.com",
   "declaredConvictions": "no",
   "declaration": 1,
-  "regIdentifier": "CBDU223",
   "metaData": {
     "dateRegistered" : "2018-05-14T10:38:17.311Z",
     "lastModified" : "2018-05-14T10:38:22.692Z",

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -37,11 +37,6 @@ Given(/^I am signed in as an Environment Agency user with refunds$/) do
   )
 end
 
-Given(/^I have a registration "([^"]*)"$/) do |reg|
-  # stores registration number for later use
-  @reg_number = reg
-end
-
 Given(/^I request assistance with a new registration$/) do
   @back_app.registrations_page.new_registration.click
   @back_app.old_start_page.submit

--- a/features/step_definitions/back_office/transfer_steps.rb
+++ b/features/step_definitions/back_office/transfer_steps.rb
@@ -1,6 +1,5 @@
-Given(/^I choose to transfer ownership of "([^"]*)" to another user$/) do |reg|
-  @reg_number = reg
-  @bo.dashboard_page.view_reg_details(search_term: reg)
+Given(/^I choose to transfer ownership of the registration to another user$/) do
+  @bo.dashboard_page.view_reg_details(search_term: @reg_number)
   @bo.registration_details_page.transfer_link.click
 end
 

--- a/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
@@ -131,9 +131,7 @@ When(/^I renew the limited company registration$/) do
 
 end
 
-Given(/^"([^"]*)" has been partially renewed by the account holder$/) do |reg|
-  # save registration number for checks later on
-  @reg_number = reg
+Given(/^the registration has been partially renewed by the account holder$/) do
   @front_app = FrontOfficeApp.new
   @renewals_app = RenewalsApp.new
   @journey = JourneyApp.new
@@ -149,9 +147,9 @@ Given(/^"([^"]*)" has been partially renewed by the account holder$/) do |reg|
   Capybara.reset_session!
 end
 
-When(/^I complete the renewal "([^"]*)" for the account holder$/) do |reg|
+When(/^I complete the renewal for the account holder$/) do
   @business_name = "Assisted digital resumed renewal"
-  @bo.dashboard_page.view_transient_reg_details(search_term: reg)
+  @bo.dashboard_page.view_transient_reg_details(search_term: @reg_number)
   @bo.registration_details_page.continue_as_ad_button.click
   @bo.ad_privacy_policy_page.submit
   @journey.confirm_business_type_page.submit
@@ -207,11 +205,9 @@ Then(/^the user has been added to the back office$/) do
   expect(@bo.migrate_page).to have_text(@user)
 end
 
-When(/^I search for "([^"]*)" pending payment$/) do |reg|
+When(/^I search for the renewal pending payment$/) do
   @bo.dashboard_page.govuk_banner.home_page.click
-  @bo.dashboard_page.view_transient_reg_details(search_term: reg)
-  # saves registration for later use
-  @reg_number = reg
+  @bo.dashboard_page.view_transient_reg_details(search_term: @reg_number)
 end
 
 When(/^I mark the renewal payment as received$/) do

--- a/features/step_definitions/back_office/upper_tier/finance_payment_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/finance_payment_steps.rb
@@ -65,12 +65,11 @@ When(/^NCCC pays the remaining balance by "([^"]*)"$/) do |method|
   @reg_balance = 0
 end
 
-Given(/^registration "([^"]*)" has an unsubmitted renewal$/) do |reg|
-  @reg_number = reg
+Given(/^the registration has an unsubmitted renewal$/) do
   @resource_object = :renewal
   @business_name = "Renewal via bank transfer"
 
-  @back_app.registrations_page.search(search_input: reg.to_sym)
+  @back_app.registrations_page.search(search_input: @reg_number.to_sym)
   @expiry_date = @back_app.registrations_page.search_results[0].expiry_date.text
   # Turns the text expiry date into a date
   @expiry_date_year_first = Date.parse(@expiry_date)
@@ -107,7 +106,6 @@ Given(/^registration "([^"]*)" has an unsubmitted renewal$/) do |reg|
   check_your_answers
   @journey.registration_cards_page.submit
   @bo.payment_summary_page.submit(choice: :bank_transfer_payment)
-
 end
 
 Then(/^I cannot access payments until the bank transfer option is selected$/) do

--- a/features/step_definitions/journey/order_cards_steps.rb
+++ b/features/step_definitions/journey/order_cards_steps.rb
@@ -1,13 +1,9 @@
-When(/^an agency user orders "([^"]*)" registration (?:card|cards) for "([^"]*)"$/) do |cards, reg|
-  @reg_number = reg
+When(/^an agency user orders "([^"]*)" registration (?:card|cards)$/) do |cards|
   @number_of_cards = cards.to_i
 
-  @bo.dashboard_page.view_reg_details(search_term: reg)
+  @bo.dashboard_page.view_reg_details(search_term: @reg_number)
   @bo.registration_details_page.order_cards_link.click
-  expect(@journey.cards_order_page.heading).to have_text("Order registration cards for " + reg)
-
-  # Look for the correct contact address for the seeded data:
-  expect(@journey.cards_order_page.contact_address).to have_text("Richard Fairclough House")
+  expect(@journey.cards_order_page.heading).to have_text("Order registration cards for " + @reg_number)
 
   # Error validation check:
   @journey.cards_order_page.submit(number_of_cards: "0")

--- a/features/step_definitions/journey/registration_steps.rb
+++ b/features/step_definitions/journey/registration_steps.rb
@@ -127,6 +127,12 @@ Given("I create a new registration for my {string} business as {string}") do |bu
   puts "#{business_type} registration " + @reg_number + " seeded"
 end
 
+Given("I have a new registration for a {string} business") do |business_type|
+  @reg_number = SeedData.seed("#{business_type}_complete_active_registration.json")
+
+  puts "#{business_type} registration " + @reg_number + " seeded"
+end
+
 Given("I create a new registration as {string} with a company name of {string}") do |account_email, company_name|
   @reg_number = SeedData.seed(
     "limitedCompany_complete_active_registration.json",
@@ -140,9 +146,25 @@ end
 Given("I have an active registration") do
   account_email = Quke::Quke.config.custom["accounts"]["waste_carrier2"]["username"]
 
-  @reg_number = SeedData.seed("limitedCompany_complete_active_registration.json", "accountEmail" => account_email)
+  @reg_number = SeedData.seed("limitedCompany_complete_active_registration.json")
 
   puts "Registration " + @reg_number + " seeded"
+end
+
+Given("I have an active registration with a company number of {string}") do |company_no|
+  account_email = Quke::Quke.config.custom["accounts"]["waste_carrier2"]["username"]
+
+  @reg_number = SeedData.seed("limitedCompany_complete_active_registration.json", "company_no" => company_no)
+
+  puts "Registration " + @reg_number + " seeded with company number of #{company_no}"
+end
+
+Given("I have an active registration with a company name of {string}") do |company_name|
+  account_email = Quke::Quke.config.custom["accounts"]["waste_carrier2"]["username"]
+
+  @reg_number = SeedData.seed("limitedCompany_complete_active_registration.json", "companyName" => company_name)
+
+  puts "Registration " + @reg_number + " seeded with company name of #{company_name}"
 end
 
 Given(/a registration with outstanding balance and (\d+) copy cards? has been submitted$/) do |copy_cards|

--- a/features/step_definitions/journey/registration_steps.rb
+++ b/features/step_definitions/journey/registration_steps.rb
@@ -146,22 +146,18 @@ end
 Given("I have an active registration") do
   account_email = Quke::Quke.config.custom["accounts"]["waste_carrier2"]["username"]
 
-  @reg_number = SeedData.seed("limitedCompany_complete_active_registration.json")
+  @reg_number = SeedData.seed("limitedCompany_complete_active_registration.json", "accountEmail" => account_email)
 
   puts "Registration " + @reg_number + " seeded"
 end
 
 Given("I have an active registration with a company number of {string}") do |company_no|
-  account_email = Quke::Quke.config.custom["accounts"]["waste_carrier2"]["username"]
-
   @reg_number = SeedData.seed("limitedCompany_complete_active_registration.json", "company_no" => company_no)
 
   puts "Registration " + @reg_number + " seeded with company number of #{company_no}"
 end
 
 Given("I have an active registration with a company name of {string}") do |company_name|
-  account_email = Quke::Quke.config.custom["accounts"]["waste_carrier2"]["username"]
-
   @reg_number = SeedData.seed("limitedCompany_complete_active_registration.json", "companyName" => company_name)
 
   puts "Registration " + @reg_number + " seeded with company name of #{company_name}"


### PR DESCRIPTION
This remove the need for any seeded data by rake task and uses the seeding api instead.

This ensure all tests can now be run without the need to run the reset_dbs task multiple times