### PR TITLE
Extend SeedData so that seeded data can be retrieved

### DIFF
--- a/features/seeds/README.md
+++ b/features/seeds/README.md
@@ -14,12 +14,14 @@ The API will respond with a JSON format which contains the `reg_identifier` of t
 An helper class called `SeedData` is part of the suite. It can be used in any step or helper method definition.
 
 ```ruby
-@reg_number = SeedData.seed("limitedCompany_complete_active_registration.json")
+seed_data = SeedData.new("limitedCompany_complete_active_registration.json")
+@reg_number = seed_data.reg_number
+@seeded_data = seed_data.seeded_data
 ```
 
 The content of the seeded entity is saved in a JSON file stored in `features/seeds/fixtures/`.
 
-To create a new entity to seed, for example an entity without payments, and hence still in progress, you can create a new file under `features/seeds/fixtures/` and use that file name as a parameter to `SeedData.seed`.
+To create a new entity to seed, for example an entity without payments, and hence still in progress, you can create a new file under `features/seeds/fixtures/` and use that file name as a parameter to `SeedData.new`.
 
 When creating a new file, the data will be the same format as in the local database, except you need to do the following:
 
@@ -29,7 +31,7 @@ When creating a new file, the data will be the same format as in the local datab
 
 ## Options
 
-The `SeedData.seed` method will accept options parameters after the file name.
+The `SeedData.new` method will accept options parameters after the file name.
 Each possible option is documented below
 
 ### Setting any top level attribute
@@ -65,7 +67,7 @@ Given that we want to create a registration using the above data but with a cust
 like this:
 
 ```ruby
-@reg_number = SeedData.seed("limitedCompany_complete_active_registration.json", "companyName" => "My new company name")
+seed_data = SeedData.new("limitedCompany_complete_active_registration.json", "companyName" => "My new company name")
 ```
 
 This will work for any attribute at the top level of the json document *as long as* the keys value matches
@@ -84,7 +86,7 @@ This option will allow the generation of a registration containing an order with
 #### Usage:
 
 ```ruby
-  SeedData.seed("outstanding_balance_pending_registration.json", copy_cards: 2)
+  SeedData.new("outstanding_balance_pending_registration.json", copy_cards: 2)
 ```
 
 #### What it does

--- a/features/seeds/seed_data.rb
+++ b/features/seeds/seed_data.rb
@@ -1,15 +1,40 @@
 # This will seed data using files in the `fixtures` subfolder.
-# Usage: SeedData.seed("limitedCompany_complete_active_registration.json")
+# Usage: SeedData.new("limitedCompany_complete_active_registration.json")
 # It will return a reg_number newly generated to use in the test suite.
 # Check README.md for more info
 
 require "net/http"
 
 class SeedData
-  def self.seed(file_name, options = {})
-    response = new(file_name, options).seed
+  def initialize(file_name, options = {})
+    @file_name = file_name
+    @options = options
+  end
 
-    JSON.parse(response.body)["reg_identifier"]
+  def reg_number
+    @_reg_number ||= JSON.parse(response.body)["reg_identifier"]
+  end
+
+  def seeded_data
+    @_seeded_data ||= JSON.parse(data)
+  end
+
+  private
+
+  attr_reader :file_name, :options
+
+  def uri
+    address = "#{Quke::Quke.config.custom['urls']['back_office']}/api/registrations"
+
+    URI.parse(address)
+  end
+
+  def response
+    @_response  ||= seed
+  end
+
+  def data
+    @_data ||= generate_data
   end
 
   def seed
@@ -21,22 +46,7 @@ class SeedData
     end
   end
 
-  private
-
-  attr_reader :file_name, :options
-
-  def initialize(file_name, options)
-    @file_name = file_name
-    @options = options
-  end
-
-  def uri
-    address = "#{Quke::Quke.config.custom['urls']['back_office']}/api/registrations"
-
-    URI.parse(address)
-  end
-
-  def data
+  def generate_data
     path_to_data_file = File.join(__dir__, "fixtures", file_name)
 
     data_content = File.read(path_to_data_file)

--- a/features/seeds/seed_data.rb
+++ b/features/seeds/seed_data.rb
@@ -30,7 +30,7 @@ class SeedData
   end
 
   def response
-    @_response  ||= seed
+    @_response ||= seed
   end
 
   def data

--- a/features/step_definitions/journey/registration_steps.rb
+++ b/features/step_definitions/journey/registration_steps.rb
@@ -110,28 +110,36 @@ Then("I am notified that my registration has been successful") do
 end
 
 Given("a registration with no convictions has been submitted by paying via card") do
-  @reg_number = SeedData.seed("limitedCompany_complete_active_registration.json")
+  seed_data = SeedData.new("limitedCompany_complete_active_registration.json")
+  @reg_number = seed_data.reg_number
+  @seeded_data = seed_data.seeded_data
 
   puts "Registration " + @reg_number + " seeded"
 end
 
 Given("I create a new registration as {string}") do |account_email|
   @tier = "upper"
-  @reg_number = SeedData.seed("limitedCompany_complete_active_registration.json", "accountEmail" => account_email)
+  seed_data = SeedData.new("limitedCompany_complete_active_registration.json", "accountEmail" => account_email)
+  @reg_number = seed_data.reg_number
+  @seeded_data = seed_data.seeded_data
 
   puts "Registration " + @reg_number + " seeded"
 end
 
 Given("I create a new registration for my {string} business as {string}") do |business_type, account_email|
   @tier = "upper"
-  @reg_number = SeedData.seed("#{business_type}_complete_active_registration.json", "accountEmail" => account_email)
+  seed_data = SeedData.new("#{business_type}_complete_active_registration.json", "accountEmail" => account_email)
+  @reg_number = seed_data.reg_number
+  @seeded_data = seed_data.seeded_data
 
   puts "#{business_type} registration " + @reg_number + " seeded"
 end
 
 Given("I have a new registration for a {string} business") do |business_type|
   @tier = "upper"
-  @reg_number = SeedData.seed("#{business_type}_complete_active_registration.json")
+  seed_data = SeedData.new("#{business_type}_complete_active_registration.json")
+  @reg_number = seed_data.reg_number
+  @seeded_data = seed_data.seeded_data
 
   puts "#{business_type} registration " + @reg_number + " seeded"
 end
@@ -140,17 +148,21 @@ Given("I have a new lower tier registration for a {string} business") do |busine
   load_all_apps
   @tier = "lower"
   @business_name = "Lower tier public body seed"
-  @reg_number = SeedData.seed("lower_#{business_type}_complete_active_registration.json", "companyName" => @business_name)
+  seed_data = SeedData.new("lower_#{business_type}_complete_active_registration.json", "companyName" => @business_name)
+  @reg_number = seed_data.reg_number
+  @seeded_data = seed_data.seeded_data
 
   puts "#{business_type} lower tier registration " + @reg_number + " seeded"
 end
 
 Given("I create a new registration as {string} with a company name of {string}") do |account_email, company_name|
-  @reg_number = SeedData.seed(
+  seed_data = SeedData.new(
     "limitedCompany_complete_active_registration.json",
     "accountEmail" => account_email,
     "companyName" => company_name
   )
+  @reg_number = seed_data.reg_number
+  @seeded_data = seed_data.seeded_data
 
   puts "Registration " + @reg_number + " seeded with name #{company_name}"
 end
@@ -159,7 +171,9 @@ Given("I have an active registration") do
   load_all_apps
   account_email = Quke::Quke.config.custom["accounts"]["waste_carrier2"]["username"]
 
-  @reg_number = SeedData.seed("limitedCompany_complete_active_registration.json", "accountEmail" => account_email)
+  seed_data = SeedData.new("limitedCompany_complete_active_registration.json", "accountEmail" => account_email)
+  @reg_number = seed_data.reg_number
+  @seeded_data = seed_data.seeded_data
   @reg_balance = 0
 
   puts "Registration " + @reg_number + " seeded"
@@ -167,14 +181,18 @@ end
 
 Given("I have an active registration with a company number of {string}") do |company_no|
   load_all_apps
-  @reg_number = SeedData.seed("limitedCompany_complete_active_registration.json", "company_no" => company_no)
+  seed_data = SeedData.new("limitedCompany_complete_active_registration.json", "company_no" => company_no)
+  @reg_number = seed_data.reg_number
+  @seeded_data = seed_data.seeded_data
 
   puts "Registration " + @reg_number + " seeded with company number of #{company_no}"
 end
 
 Given("I have an active registration with a company name of {string}") do |company_name|
   load_all_apps
-  @reg_number = SeedData.seed("limitedCompany_complete_active_registration.json", "companyName" => company_name)
+  seed_data = SeedData.new("limitedCompany_complete_active_registration.json", "companyName" => company_name)
+  @reg_number = seed_data.reg_number
+  @seeded_data = seed_data.seeded_data
   @business_name = company_name
   @tier = "upper"
   @resource_object = :registration
@@ -188,7 +206,9 @@ Given(/a registration with outstanding balance and (\d+) copy cards? has been su
   @reg_balance = 154 + 5 * copy_cards
   @business_name = "Outstanding Balance Limited"
 
-  @reg_number = SeedData.seed("outstanding_balance_pending_registration.json", copy_cards: copy_cards)
+  seed_data = SeedData.new("outstanding_balance_pending_registration.json", copy_cards: copy_cards)
+  @reg_number = seed_data.reg_number
+  @seeded_data = seed_data.seeded_data
 
   puts "Registration " + @reg_number + " seeded with #{copy_cards} copy cards and outstanding balance"
 end


### PR DESCRIPTION
I was requested by Andrew to see if there is a way we can save the seeded data in a variable so that later in the tests we can access the seeded data and use them to check contents match the info in the seeded registration. This PR implement that change.