### PR TITLE
Update page objects for AD renewals and tweak features

### DIFF
--- a/features/bo_new/dashboard/convictions.feature
+++ b/features/bo_new/dashboard/convictions.feature
@@ -1,8 +1,10 @@
-@bo_new @convictions @smoke @bo_reg
+@bo_new @convictions @smoke @bo_dashboard
 Feature: Conviction checks during upper tier waste carrier registrations
   As a waste carrier administrator
   I want to check whether any known companies or individuals have any previous waste convictions
   So that I can decide whether they are allowed to hold a waste carriers licence
+
+  (Registrations are completed on the new app for this feature.)
 
   Background:
    Given an Environment Agency user has signed in to the backend

--- a/features/bo_new/dashboard/order_cards.feature
+++ b/features/bo_new/dashboard/order_cards.feature
@@ -1,8 +1,10 @@
-@bo_new @bo_dashboard
+@bo_new @bo_dashboard @broken
 Feature: [RUBY-767] NCCC agent orders registration cards from back office
   As an NCCC agent
   I want to order registration cards
   So that I can help a waste carrier prove they are registered
+
+  Functionality is currently broken in mock mode!
 
 Background:
 	Given I sign into the back office as "agency-user"

--- a/features/bo_new/dashboard/revert_to_payment_summary.feature
+++ b/features/bo_new/dashboard/revert_to_payment_summary.feature
@@ -1,21 +1,23 @@
-@bo_new @bo_dashboard
+@bo_new @bo_dashboard @wip
 Feature: NCCC agent unblocks a registration from back office
   As an NCCC agent
   I want to unblock a registration using a back office function
   So that I can allow the customer to complete their application
 
-Background:
-  Given I start a new registration
-   And I complete my application of my limited company as an upper tier waste carrier using my email "user@example.com"
-   And I pay for my application by maestro ordering 0 copy cards
-   And I have signed in the front office using my email
-   And I renew my last registration
-   And I complete my limited liability partnership renewal steps and get stuck
+This test will not work if Worldpay mocking is turned on as it relies on the user stopping the journey on the WorldPay page.
 
-Scenario: NCCC unblocks a stuck renewal registration
-  Given I sign into the back office as "agency-user"
-    And I revert the last renewal to payment summary
-  Then the user is able to complete their renewal
+# Background:
+#   Given I start a new registration
+#    And I complete my application of my limited company as an upper tier waste carrier using my email "user@example.com"
+#    And I pay for my application by maestro ordering 0 copy cards
+#    And I have signed in the front office using my email
+#    And I start renewing my last registration from the frontend
+#    And I complete my limited liability partnership renewal steps and get stuck
+#
+# Scenario: NCCC unblocks a stuck renewal registration
+#   Given I sign into the back office as "agency-user"
+#     And I revert the last renewal to payment summary
+#   Then the user is able to complete their renewal
 
 # Scenario: NCCC unblock a stuck new registration
   # pending implementation

--- a/features/bo_new/dashboard/revert_to_payment_summary.feature
+++ b/features/bo_new/dashboard/revert_to_payment_summary.feature
@@ -1,4 +1,4 @@
-@bo_new @bo_dashboard @wip
+@bo_new @bo_dashboard
 Feature: NCCC agent unblocks a registration from back office
   As an NCCC agent
   I want to unblock a registration using a back office function

--- a/features/bo_new/dashboard/revert_to_payment_summary.feature
+++ b/features/bo_new/dashboard/revert_to_payment_summary.feature
@@ -1,23 +1,23 @@
-@bo_new @bo_dashboard
+@bo_new @bo_dashboard @broken
 Feature: NCCC agent unblocks a registration from back office
   As an NCCC agent
   I want to unblock a registration using a back office function
   So that I can allow the customer to complete their application
 
-This test will not work if Worldpay mocking is turned on as it relies on the user stopping the journey on the WorldPay page.
+  This test will not work if Worldpay mocking is turned on as it relies on the user stopping the journey on the WorldPay page. Fix requested in RUBY-1035.
 
-# Background:
-#   Given I start a new registration
-#    And I complete my application of my limited company as an upper tier waste carrier using my email "user@example.com"
-#    And I pay for my application by maestro ordering 0 copy cards
-#    And I have signed in the front office using my email
-#    And I start renewing my last registration from the frontend
-#    And I complete my limited liability partnership renewal steps and get stuck
-#
-# Scenario: NCCC unblocks a stuck renewal registration
-#   Given I sign into the back office as "agency-user"
-#     And I revert the last renewal to payment summary
-#   Then the user is able to complete their renewal
+Background:
+  Given I start a new registration
+   And I complete my application of my limited company as an upper tier waste carrier using my email "user@example.com"
+   And I pay for my application by maestro ordering 0 copy cards
+   And I have signed in the front office using my email
+   And I start renewing my last registration from the frontend
+   And I complete my limited liability partnership renewal steps and get stuck
+
+Scenario: NCCC unblocks a stuck renewal registration
+  Given I sign into the back office as "agency-user"
+    And I revert the last renewal to payment summary
+  Then the user is able to complete their renewal
 
 # Scenario: NCCC unblock a stuck new registration
   # pending implementation

--- a/features/bo_old/dashboard/user_management.feature
+++ b/features/bo_old/dashboard/user_management.feature
@@ -1,4 +1,4 @@
-@bo_old @bo_dashboard
+@bo_old
 Feature: User management feature
 As a super user
 I need to copy the users I have created in the backend into the back office

--- a/features/fo_new/new_registration/upper_tier.feature
+++ b/features/fo_new/new_registration/upper_tier.feature
@@ -1,4 +1,4 @@
-@fo_new @fo_reg @smoke @minismoke
+@fo_new @fo_reg @smoke @minismoke @wip
 Feature: A new user registers as an upper tier waste carrier
   As a carrier of commercial waste
   I want to register for an upper tier licence

--- a/features/fo_new/new_registration/upper_tier.feature
+++ b/features/fo_new/new_registration/upper_tier.feature
@@ -1,4 +1,4 @@
-@fo_new @fo_reg @smoke @minismoke @wip
+@fo_new @fo_reg @smoke @minismoke
 Feature: A new user registers as an upper tier waste carrier
   As a carrier of commercial waste
   I want to register for an upper tier licence

--- a/features/page_objects/back_office/new/registration_details_page.rb
+++ b/features/page_objects/back_office/new/registration_details_page.rb
@@ -15,7 +15,7 @@ class RegistrationDetailsPage < SitePrism::Page
   element(:business_name, ".wcr-panel-border-all .heading-medium")
 
   element(:actions_box, ".wcr-actions--push-down")
-  element(:renew_link, "a[href*='/ad-privacy-policy/CBD']")
+  element(:renew_link, "a[href*='/ad-privacy-policy?reg_identifier=CBD']")
   element(:transfer_link, "a[href*='/transfer']")
   element(:edit_link, "a[href*='/edit']")
   element(:view_certificate_link, "a[href*='/certificate']")

--- a/features/page_objects/front_office/registrations/business_details_page.rb
+++ b/features/page_objects/front_office/registrations/business_details_page.rb
@@ -6,7 +6,7 @@ class BusinessDetailsPage < SitePrism::Page
   element(:company_name, "#registration_companyName")
   element(:postcode, "#sPostcode")
   element(:find_address, "#find_address")
-  element(:results_dropdown, "select#registration_selectedAddress")
+  element(:results_dropdown, "#registration_selectedAddress")
 
   element(:submit_button, "input[value='Continue']")
 
@@ -15,6 +15,7 @@ class BusinessDetailsPage < SitePrism::Page
     company_name.set(args[:company_name]) if args.key?(:company_name)
     postcode.set(args[:postcode]) if args.key?(:postcode)
     find_address.click
+
     results_dropdown.select(args[:result]) if args.key?(:result)
 
     submit_button.click

--- a/features/step_definitions/back_office/upper_tier/revert_to_payment_summary_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/revert_to_payment_summary_steps.rb
@@ -12,7 +12,6 @@ end
 When("I revert the last renewal to payment summary") do
   visit_renewal_details_page(@reg_number)
 
-  puts page.text
   @bo.registration_details_page.revert_to_payment_summary_link.click
 end
 

--- a/features/step_definitions/back_office/upper_tier/revert_to_payment_summary_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/revert_to_payment_summary_steps.rb
@@ -1,18 +1,18 @@
 require "pry"
 
-When(/^I renew my last registration"$/) do
+When("I start renewing my last registration from the frontend") do
   @renewals_app = RenewalsApp.new
   @journey = JourneyApp.new
   @renewals_app.old_start_page.load
   @renewals_app.old_start_page.submit(renewal: true)
-  @renewals_app.existing_registration_page.submit(reg_no: reg)
-  # save registration number for checks later on
-  @reg_number = reg
+  @renewals_app.existing_registration_page.submit(reg_no: @reg_number)
+  expect(page).to have_text("You are about to renew registration " + @reg_number)
 end
 
 When("I revert the last renewal to payment summary") do
   visit_renewal_details_page(@reg_number)
 
+  puts page.text
   @bo.registration_details_page.revert_to_payment_summary_link.click
 end
 

--- a/features/step_definitions/front_office/general_steps.rb
+++ b/features/step_definitions/front_office/general_steps.rb
@@ -19,6 +19,7 @@ When(/^I pay for my application by maestro ordering (\d+) copy (?:card|cards)$/)
   submit_valid_card_payment
 
   @reg_number = find("#registrationNumber").text
+  puts "Registration " + @reg_number + " completed by card"
 end
 
 Then(/^I will be asked to confirm my email address$/) do


### PR DESCRIPTION
This is a small maintenance update which:

* Updates page objects for assisted digital renewals
* Marks two tests which are broken due to mocking issues
* Tidies tags so that tests can be run by folder