### PR TITLE
Fix charity renewal scenario

### DIFF
--- a/features/fo_new/renewals/payments.feature
+++ b/features/fo_new/renewals/payments.feature
@@ -1,4 +1,4 @@
-@fo_new @fo_renewalNO @renewal
+@fo_new @fo_renewal @renewal
 Feature: Registered waste carrier pays for their renewal
   As a carrier of commercial waste
   I want to be able to pay the relevant charge for my renewal

--- a/features/fo_new/renewals/payments.feature
+++ b/features/fo_new/renewals/payments.feature
@@ -1,4 +1,4 @@
-@fo_new @fo_renewal @renewal
+@fo_new @fo_renewalNO @renewal
 Feature: Registered waste carrier pays for their renewal
   As a carrier of commercial waste
   I want to be able to pay the relevant charge for my renewal

--- a/features/fo_new/renewals/renewal_changes.feature
+++ b/features/fo_new/renewals/renewal_changes.feature
@@ -5,49 +5,49 @@ Feature: Registered waste carrier chooses to renew their registration from start
   So my details are up to date and I continue to be compliant with the law
 
     Scenario: Limited company changes business type and is informed to create a new registration
-      Given I create a new registration for my "limitedCompany" business as "user@example.com"
+      Given I create an upper tier registration for my "limitedCompany" business as "user@example.com"
         And I renew my last registration
         And I have signed in to renew my registration as "user@example.com"
         But I change the business type to "localAuthority"
        Then I will be notified "You need a new registration"
 
    Scenario: Sole trader changes place of business location to outside the UK
-      Given I create a new registration for my "soleTrader" business as "user@example.com"
+      Given I create an upper tier registration for my "soleTrader" business as "user@example.com"
         And I renew my last registration
         And I have signed in to renew my registration as "user@example.com"
         But I change my place of business location to "overseas"
        Then I will be able to continue my renewal
 
   Scenario: Sole trader changes place of business location to Scotland
-      Given I create a new registration for my "soleTrader" business as "user@example.com"
+      Given I create an upper tier registration for my "soleTrader" business as "user@example.com"
         And I renew my last registration
         And I have signed in to renew my registration as "user@example.com"
         But I change my place of business location to "scotland"
        Then I will be notified "You can register in Scotland"
 
     Scenario: On renewal a partnership changes its registration type causing a £40 charge for the change
-      Given I create a new registration for my "partnership" business as "user@example.com"
+      Given I create an upper tier registration for my "partnership" business as "user@example.com"
         And I renew my last registration
         And I have signed in to renew my registration as "user@example.com"
        When I change my carrier broker dealer type to "carrier_broker_dealer"
        Then I will be advised "Because your carrier type has changed, there will also be a £40 charge"
 
     Scenario: On renewal a sole trader answers questions that direct to lower tier
-      Given I create a new registration for my "soleTrader" business as "user@example.com"
+      Given I create an upper tier registration for my "soleTrader" business as "user@example.com"
         And I renew my last registration
         And I have signed in to renew my registration as "user@example.com"
        When I answer questions indicating I should be a lower tier waste carrier
        Then I will be notified "You can register as a lower tier waste carrier"
 
   Scenario: Partnership changes business type to Limited Liability Partnership
-      Given I create a new registration for my "partnership" business as "user@example.com"
+      Given I create an upper tier registration for my "partnership" business as "user@example.com"
         And I renew my last registration
         And I have signed in to renew my registration as "user@example.com"
         But I change the business type to "limitedLiabilityPartnership"
        Then I will be able to continue my renewal
 
   Scenario: Limited company changes companies house number and is informed to create a new registration
-      Given I create a new registration for my "limitedCompany" business as "user@example.com"
+      Given I create an upper tier registration for my "limitedCompany" business as "user@example.com"
         And I renew my last registration
         And I have signed in to renew my registration as "user@example.com"
         But I change my companies house number to "10926928"

--- a/features/fo_new/renewals/renewals.feature
+++ b/features/fo_new/renewals/renewals.feature
@@ -6,7 +6,7 @@ Feature: Registered waste carrier chooses to renew their registration from regis
 
   @email
   Scenario: Sole trader renews upper tier registration from renewals page
-    Given I create a new registration for my "soleTrader" business as "wcr-user@mailinator.com"
+    Given I create an upper tier registration for my "soleTrader" business as "wcr-user@mailinator.com"
       And I renew my last registration
       And I have signed in to renew my registration as "wcr-user@mailinator.com"
      When I complete my sole trader renewal steps
@@ -15,21 +15,19 @@ Feature: Registered waste carrier chooses to renew their registration from regis
 
   @smoke
   Scenario: Limited liability partnership renews upper tier registration from renewals page
-    Given I create a new registration for my "limitedLiabilityPartnership" business as "user@example.com"
+    Given I create an upper tier registration for my "limitedLiabilityPartnership" business as "user@example.com"
       And I renew my last registration
       And I have signed in to renew my registration as "user@example.com"
      When I complete my limited liability partnership renewal steps
      Then I will be notified my renewal is complete
 
-    Scenario: Charity renews upper tier registration from renewals page and is notified to register as lower tier
-      Given I create a new registration for my "charity" business as "user@example.com"
+    Scenario: Charity renews registration from renewals page and is notified to register as lower tier
+      Given I create a lower tier registration for my "charity" business as "user@example.com"
         And I renew my last registration
-        And I have signed in to renew my registration as "user@example.com"
-       When I confirm my business type
-       Then I will be notified "You can register as a lower tier waste carrier"
+       Then I am told that my registration does not expire
 
   Scenario: Partnership renews upper tier registration from renewals page
-    Given I create a new registration for my "partnership" business as "user@example.com"
+    Given I create an upper tier registration for my "partnership" business as "user@example.com"
       And I renew my last registration
       And I have signed in to renew my registration as "user@example.com"
      When I complete my partnership renewal steps
@@ -45,7 +43,7 @@ Feature: Registered waste carrier chooses to renew their registration from regis
 
 # Combine this with partner scenario above
   Scenario: Partnership renews upper tier registration but requires more than one partner to renew
-    Given I create a new registration for my "partnership" business as "user@example.com"
+    Given I create an upper tier registration for my "partnership" business as "user@example.com"
       And I renew my last registration
       And I have signed in to renew my registration as "user@example.com"
      When I add two partners to my renewal
@@ -53,7 +51,7 @@ Feature: Registered waste carrier chooses to renew their registration from regis
      Then I will be asked to add another partner
 
   Scenario: Limited liability partnership renews upper tier registration from renewals page
-    Given I create a new registration for my "limitedLiabilityPartnership" business as "user@example.com"
+    Given I create an upper tier registration for my "limitedLiabilityPartnership" business as "user@example.com"
       And I renew my last registration
       And I have signed in to renew my registration as "user@example.com"
      When I complete my limited liability partnership renewal steps choosing to pay by bank transfer

--- a/features/fo_new/renewals/renewals_from_user_registrations_page.feature
+++ b/features/fo_new/renewals/renewals_from_user_registrations_page.feature
@@ -6,7 +6,7 @@ Feature: Registered waste carrier chooses to renew their registration from regis
 
   @smoke
   Scenario: Limited company renews upper tier registration from registrations list
-      Given I create a new registration for my "limitedCompany" business as "another-user@example.com"
+      Given I create an upper tier registration for my "limitedCompany" business as "another-user@example.com"
         And I have signed in to view my registrations as "another-user@example.com"
   	    And I choose to renew my last registration from the dashboard
       When I complete my limited company renewal steps

--- a/features/seeds/fixtures/lower_charity_complete_active_registration.json
+++ b/features/seeds/fixtures/lower_charity_complete_active_registration.json
@@ -1,0 +1,71 @@
+{
+    "location" : "england",
+    "businessType" : "charity",
+    "tier" : "LOWER",
+    "companyName" : "lower tier charity new registration",
+    "firstName" : "Gustavo",
+    "lastName" : "Fring",
+    "phoneNumber" : "0117 4960000",
+    "contactEmail" : "user@example.com",
+    "accountEmail": "user@example.com",
+    "declaration" : 1,
+    "addresses" : [
+        {
+            "uprn" : 340116,
+            "addressMode" : "address-results",
+            "dependentLocality" : "",
+            "administrativeArea" : "BRISTOL",
+            "townCity" : "BRISTOL",
+            "postcode" : "BS1 5AH",
+            "country" : "",
+            "localAuthorityUpdateDate" : "",
+            "easting" : 358205,
+            "northing" : 172708,
+            "houseNumber" : "ENVIRONMENT AGENCY",
+            "addressLine1" : "DEANERY ROAD",
+            "addressType" : "REGISTERED"
+        },
+        {
+            "uprn" : 340116,
+            "addressMode" : "address-results",
+            "dependentLocality" : "",
+            "administrativeArea" : "BRISTOL",
+            "townCity" : "BRISTOL",
+            "postcode" : "BS1 5AH",
+            "country" : "",
+            "localAuthorityUpdateDate" : "",
+            "easting" : 358205,
+            "northing" : 172708,
+            "houseNumber" : "ENVIRONMENT AGENCY",
+            "addressLine1" : "DEANERY ROAD",
+            "addressType" : "POSTAL"
+        }
+    ],
+    "financeDetails" : {
+        "balance" : 0,
+        "orders" : [
+            {
+                "orderId" : "1588675627",
+                "orderCode" : "1588675627",
+                "currency" : "GBP",
+                "dateCreated" : "2020-05-05T10:47:07.355Z",
+                "dateLastUpdated" : "2020-05-05T10:47:07.355Z",
+                "updatedByUser" : "9685578@example.com",
+                "description" : null,
+                "totalAmount" : 0,
+                "paymentMethod" : "ONLINE",
+                "worldPayStatus" : "IN_PROGRESS",
+                "merchantId" : "EASERRSIMECOM"
+            }
+        ]
+    },
+    "metaData" : {
+        "status" : "ACTIVE",
+        "lastModified" : "2020-05-05T10:47:07.376Z",
+        "route" : "DIGITAL",
+        "dateRegistered" : "2020-05-05T10:47:07.372Z",
+        "dateActivated" : "2020-05-05T10:47:07.411Z"
+    },
+    "locked_at" : null,
+    "locking_name" : null
+}

--- a/features/step_definitions/front_office/renewal_steps.rb
+++ b/features/step_definitions/front_office/renewal_steps.rb
@@ -39,6 +39,10 @@ Then(/^I'm informed "([^"]*)"$/) do |error_message|
   expect(@renewals_app.existing_registration_page.error_message.text).to eq(error_message)
 end
 
+Given("I am told that my registration does not expire") do
+  expect(page).to have_text("This is a lower tier registration so never expires. Call our helpline on 03708 506506 if you think this is incorrect.")
+end
+
 When(/^the organisation type is changed to sole trader$/) do
   agree_to_renew_in_england
   @journey.confirm_business_type_page.submit(org_type: "soleTrader")

--- a/features/step_definitions/journey/registration_steps.rb
+++ b/features/step_definitions/journey/registration_steps.rb
@@ -126,13 +126,22 @@ Given("I create a new registration as {string}") do |account_email|
   puts "Registration " + @reg_number + " seeded"
 end
 
-Given("I create a new registration for my {string} business as {string}") do |business_type, account_email|
+Given("I create an upper tier registration for my {string} business as {string}") do |business_type, account_email|
   @tier = "upper"
   seed_data = SeedData.new("#{business_type}_complete_active_registration.json", "accountEmail" => account_email)
   @reg_number = seed_data.reg_number
   @seeded_data = seed_data.seeded_data
 
-  puts "#{business_type} registration " + @reg_number + " seeded"
+  puts "#{business_type} upper tier registration " + @reg_number + " seeded"
+end
+
+Given("I create a lower tier registration for my {string} business as {string}") do |business_type, account_email|
+  @tier = "lower"
+  seed_data = SeedData.new("lower_#{business_type}_complete_active_registration.json", "accountEmail" => account_email)
+  @reg_number = seed_data.reg_number
+  @seeded_data = seed_data.seeded_data
+
+  puts "#{business_type} lower tier registration " + @reg_number + " seeded"
 end
 
 Given("I have a new registration for a {string} business") do |business_type|


### PR DESCRIPTION
In a previous update I had broken the seeded data for this test, which checks what happens when a charity attempts to renew their registration. I've also simplified the test to make it more live-like.

Finally I've updated the step names to specify whether seeded data is lower or upper tier.