### PR TITLE
Fix payment feature

### DIFF
--- a/.config.yml
+++ b/.config.yml
@@ -113,6 +113,7 @@ custom:
     last_email_fe: "http://localhost:3000/email/last-email"
     last_email_fo: "http://localhost:3002/fo/email/last-email"
     last_email_bo: "http://localhost:8001/bo/email/last-email"
+    mock_enabled: "http://localhost:3002/fo/mocks/company/00445790"
 
   # # Dev setup
   # urls:
@@ -130,6 +131,7 @@ custom:
   #   last_email_fe: "https://waste-carriers-dev.aws.defra.cloud/email/last-email"
   #   last_email_fo: "https://waste-carriers-dev.aws.defra.cloud/fo/email/last-email"
   #   last_email_bo: "https://admin-waste-carriers-dev.aws.defra.cloud/bo/email/last-email"
+  #   mock_enabled: "https://waste-carriers-dev.aws.defra.cloud/fo/mocks/company/00445790"
 
   # # Test setup
   # urls:
@@ -147,6 +149,7 @@ custom:
   #   last_email_fe: "https://waste-carriers-tst.aws.defra.cloud/email/last-email"
   #   last_email_fo: "https://waste-carriers-tst.aws.defra.cloud/fo/email/last-email"
   #   last_email_bo: "https://admin-waste-carriers-tst.aws.defra.cloud/bo/email/last-email"
+  #   mock_enabled: "https://waste-carriers-tst.aws.defra.cloud/fo/mocks/company/00445790"
 
   # # Preprod / staging setup
   # urls:
@@ -164,6 +167,7 @@ custom:
   #   last_email_fe: "https://waste-carriers-pre.aws.defra.cloud/email/last-email"
   #   last_email_fo: "https://waste-carriers-pre.aws.defra.cloud/fo/email/last-email"
   #   last_email_bo: "https://admin-waste-carriers-pre.aws.defra.cloud/bo/email/last-email"
+  #   mock_enabled: "https://waste-carriers-pre.aws.defra.cloud/fo/mocks/company/00445790"
 
 # If you are running Quke behind a proxy you can configure the proxy details
 # here. You'll need either the hostname or IP of the proxy server (don't include

--- a/features/fo_new/renewals/payments.feature
+++ b/features/fo_new/renewals/payments.feature
@@ -8,7 +8,8 @@ Feature: Registered waste carrier pays for their renewal
 # a payment can be rejected by submitting business details with 'reject' in the name
 
     Scenario: Rejected worldpay payment can be paid for on another credit card
-      Given I create a new registration as "user@example.com"
+      Given mocking is disabled
+        And I create a new registration as "user@example.com"
         And I renew my last registration
         And I have signed in to renew my registration as "user@example.com"
         And I am on the payment page
@@ -25,11 +26,12 @@ Feature: Registered waste carrier pays for their renewal
         But I have my credit card payment rejected
        When I can pay by bank transfer
        Then I will be notified my renewal is pending payment
-        And I will receive a renewal appliction received email
+        And I will receive an email informing me "You need to pay for your waste carriers registration"
 
 # This test can't work if the mock is in place, as there's no cancel option
     Scenario: Cancelled worldpay payment can be paid for by retrying card payment
-      Given I create a new registration as "user@example.com"
+      Given mocking is disabled
+        And I create a new registration as "user@example.com"
         And I renew my last registration
         And I have signed in to renew my registration as "user@example.com"
         And I am on the payment page

--- a/features/fo_new/renewals/renewal_convictions_checks.feature
+++ b/features/fo_new/renewals/renewal_convictions_checks.feature
@@ -11,7 +11,7 @@ Feature: Registered waste carrier declares conviction during renewal
   	  And I have signed in to renew my registration as "wcr-user@mailinator.com"
     When I complete my limited company renewal steps declaring a conviction
   	Then I will be notified my renewal is pending checks
-      And I will receive a renewal appliction received email
+      And I will receive a renewal application received email
 
   Scenario: Limited company renews upper tier registration from renewals page not declaring conviction
   	Given I create a new registration as "user@example.com"

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -8,6 +8,10 @@ Given(/^an Environment Agency user has signed in to the backend$/) do
   )
 end
 
+Given("mocking is disabled") do
+  pending "It makes no sense to test this feature when mocking is enabled" if mocking_enabled?
+end
+
 Given(/^I sign into the back office as "([^"]*)"$/) do |user|
   # Use this step to sign in to the back office as any of the following users:
   # agency-user

--- a/features/step_definitions/email/email_steps.rb
+++ b/features/step_definitions/email/email_steps.rb
@@ -56,7 +56,7 @@ Then(/^I will receive an email informing me "([^"]*)"$/) do |text|
   end
 end
 
-Then(/^I will receive a renewal appliction received email$/) do
+Then(/^I will receive a renewal applictaion received email$/) do
   if @email_app.local?
     @email_app.mailcatcher_main_page.open_email(1)
     expect(@email_app.mailcatcher_messages_page).to have_text("Your application to renew")

--- a/features/step_definitions/email/email_steps.rb
+++ b/features/step_definitions/email/email_steps.rb
@@ -56,7 +56,7 @@ Then(/^I will receive an email informing me "([^"]*)"$/) do |text|
   end
 end
 
-Then(/^I will receive a renewal applictaion received email$/) do
+Then(/^I will receive a renewal application received email$/) do
   if @email_app.local?
     @email_app.mailcatcher_main_page.open_email(1)
     expect(@email_app.mailcatcher_messages_page).to have_text("Your application to renew")

--- a/features/step_definitions/front_office/payment_steps.rb
+++ b/features/step_definitions/front_office/payment_steps.rb
@@ -19,15 +19,19 @@ Given(/^I am on the payment page$/) do
 end
 
 When(/^I have my credit card payment rejected$/) do
-  # This step will not work when WorldPay mocking is in place, so commented out for now
-  # @renewals_app.payment_summary_page.submit(choice: :card_payment)
-  # submit_invalid_card_payment
+  # This step will not work when WorldPay mocking is in place
+  unless mocking_enabled?
+    @renewals_app.payment_summary_page.submit(choice: :card_payment)
+    submit_invalid_card_payment
+  end
 end
 
 When(/^I cancel my credit card payment$/) do
-  # This step will not work when WorldPay mocking is in place, so commented out for now
-  # @renewals_app.payment_summary_page.submit(choice: :card_payment)
-  # @journey.worldpay_payment_page.cancel_payment
+  # This step will not work when WorldPay mocking is in place
+  unless mocking_enabled?
+    @renewals_app.payment_summary_page.submit(choice: :card_payment)
+    @journey.worldpay_payment_page.cancel_payment
+  end
 end
 
 Then(/^(?:I can pay with another card|I try my credit card payment again)$/) do

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -11,6 +11,22 @@ def load_all_apps
   @renewals_app = RenewalsApp.new
 end
 
+def mocking_enabled?
+  # Simple helper to check if mocking is currently enabled.
+  # It is based on the fact that the mock gem uses URL constraints,
+  # hence when we hit a mocking valid URL, if we receive a 404 response back,
+  # we can assume that mocking is disabled
+  uri = URI.parse(Quke::Quke.config.custom["urls"]["mock_enabled"])
+
+  # using an instance variable so that we make the request to the mocking
+  # endpoint only once
+  @_mocking_enabled_response ||= Net::HTTP.get_response(uri)
+
+  return false if @_mocking_enabled_response == "404"
+
+  true
+end
+
 def sign_in_to_front_end_if_necessary(email)
   @renewals_app = RenewalsApp.new
 


### PR DESCRIPTION
Close: https://github.com/DEFRA/waste-carriers-acceptance-tests/issues/300

This PR contains the addition of an helper method that will allow the suite to check if it is running in an environment were mocking is enabled.

This method is then used in a couple of tests that are specific to test worldpay behaviour. In order to skip an entire scenario running, I have created a new `Given` that will appear pending and will output an useful message when mocking is enabled. The first `Given` being pending will cause the scenario to not run.

This also fixes an issue with checking the content of the email when a renewal is submitted with a pending bank transfer. Since we recently updated the content of that email to be in line with what is sent via new registration, we also needed to update the scenario to reflect the latest changes. I chose to use the general email scenario as it was very handy.