### PR TITLE
Remove backend dependency for convictions tests

### DIFF
--- a/.config.yml
+++ b/.config.yml
@@ -19,7 +19,7 @@ app_host: 'http://localhost:3000'
 driver: chrome
 
 # Runs either Chrome or Firefox driver headlessly if set to true
-headless: false
+headless: true
 
 parallel: false
 

--- a/.config.yml
+++ b/.config.yml
@@ -19,7 +19,7 @@ app_host: 'http://localhost:3000'
 driver: chrome
 
 # Runs either Chrome or Firefox driver headlessly if set to true
-headless: true
+headless: false
 
 parallel: false
 

--- a/Rakefile
+++ b/Rakefile
@@ -129,18 +129,6 @@ task :Google_Pixel do
   sh %( QUKE_CONFIG=.config_Google_Pixel.yml bundle exec quke --tags @dashboard --tags ~@broken)
 end
 
-desc "Run all renewal tests"
-task :renewals do
-  reset_dbs
-  sh %( QUKE_CONFIG=.config.yml bundle exec quke --tags @renewal --tags ~@todo --tags ~@broken --tags ~@email)
-end
-
-desc "Run all registration tests"
-task :registrations do
-  reset_dbs
-  sh %( QUKE_CONFIG=.config.yml bundle exec quke --tags ~@renewal --tags ~@todo --tags ~@broken --tags ~@email)
-end
-
 task :all_tests do
   reset_dbs
   sh %( QUKE_CONFIG=.config.yml bundle exec quke --tags --tags ~@todo --tags ~@broken --tags ~@email)

--- a/features/bo_new/dashboard/cancel.feature
+++ b/features/bo_new/dashboard/cancel.feature
@@ -1,5 +1,5 @@
 @bo_new @bo_dashboard @smoke
-Feature: NCCC agent cancel in progress registration from back office
+Feature: NCCC agent cancels in progress registration from back office
   As an NCCC agent
   I want to cancel an in-progress registration
   So that we can correctly regulate the waste activity

--- a/features/bo_new/dashboard/convictions.feature
+++ b/features/bo_new/dashboard/convictions.feature
@@ -4,10 +4,7 @@ Feature: Conviction checks during upper tier waste carrier registrations
   I want to check whether any known companies or individuals have any previous waste convictions
   So that I can decide whether they are allowed to hold a waste carriers licence
 
-  (Registrations are completed on the new app for this feature.)
-
-  Background:
-   Given an Environment Agency user has signed in to the backend
+  (Registrations are completed on the front office for this feature.)
 
   Scenario: Limited company with an undeclared conviction match by company number is marked for a conviction check
   	Given a limited company with companies house number "01649776" is registered as an upper tier waste carrier

--- a/features/bo_new/renewals/assisted_digital_renewal.feature
+++ b/features/bo_new/renewals/assisted_digital_renewal.feature
@@ -1,4 +1,4 @@
-@bo_new @bo_renew @renewal
+@bo_new @bo_renew
 
 Feature: Assisted digital renewal of an upper tier public body
   As a carrier of commercial waste

--- a/features/bo_new/renewals/incomplete_registration_completed_with_assistance.feature
+++ b/features/bo_new/renewals/incomplete_registration_completed_with_assistance.feature
@@ -1,4 +1,4 @@
-@bo_new @bo_renew @renewal
+@bo_new @bo_renew
 
 Feature: Incomplete renewal of an upper tier public body completed by NCCC
   As a carrier of commerical waste

--- a/features/fo_new/renewals/payments.feature
+++ b/features/fo_new/renewals/payments.feature
@@ -1,4 +1,4 @@
-@fo_new @fo_renewal @renewal @broken
+@fo_new @fo_renewal @broken
 Feature: Registered waste carrier pays for their renewal
   As a carrier of commercial waste
   I want to be able to pay the relevant charge for my renewal

--- a/features/fo_new/renewals/renewal_changes.feature
+++ b/features/fo_new/renewals/renewal_changes.feature
@@ -1,4 +1,4 @@
-@fo_new @fo_renewal @renewal
+@fo_new @fo_renewal
 Feature: Registered waste carrier chooses to renew their registration from start page
   As a carrier of commercial waste
   I want to change my registration details when I renew my waste carriers licence with the Environment Agency

--- a/features/fo_new/renewals/renewal_convictions_checks.feature
+++ b/features/fo_new/renewals/renewal_convictions_checks.feature
@@ -1,4 +1,4 @@
-@fo_new @fo_renewal @renewal @convictions
+@fo_new @fo_renewal
 Feature: Registered waste carrier declares conviction during renewal
   As a member of the waste carriers team in NCCC
   I want to be informed of any potential matches with the Environment Agency's convictions database

--- a/features/fo_new/renewals/renewals.feature
+++ b/features/fo_new/renewals/renewals.feature
@@ -1,4 +1,4 @@
-@fo_new @fo_renewal @renewal
+@fo_new @fo_renewal
 Feature: Registered waste carrier chooses to renew their registration from registration search
   As a carrier of commercial waste
   I want to renew my waste carriers licence with the Environment Agency

--- a/features/fo_new/renewals/renewals_from_user_registrations_page.feature
+++ b/features/fo_new/renewals/renewals_from_user_registrations_page.feature
@@ -1,4 +1,4 @@
-@fo_new @fo_renewal @renewal @fo_dashboard
+@fo_new @fo_renewal
 Feature: Registered waste carrier chooses to renew their registration from registrations account page
   As a carrier of commercial waste
   I want to renew my waste carriers licence with the Environment Agency

--- a/features/fo_old/upper_partnership_registration.feature
+++ b/features/fo_old/upper_partnership_registration.feature
@@ -1,4 +1,4 @@
-@fo_old
+@fo_old @fo_reg
 Feature: Partnership applies for new upper tier registration
   As a carrier of commercial waste
   I want to register my partnership with the Environment Agency

--- a/features/fo_old/upper_public_body_registration.feature
+++ b/features/fo_old/upper_public_body_registration.feature
@@ -1,4 +1,4 @@
-@fo_old
+@fo_old @fo_reg
 Feature: Public body applies for new upper tier registration
   As a carrier of commercial waste
   I want to register my public body with the Environment Agency

--- a/features/fo_old/upper_sole_trader_registration.feature
+++ b/features/fo_old/upper_sole_trader_registration.feature
@@ -1,4 +1,4 @@
-@fo_old
+@fo_old @fo_reg
 Feature: Sole trader applies for new upper tier registration
   As a carrier of commercial waste
   I want to register my sole trader business with the Environment Agency

--- a/features/page_objects/front_office/registrations/key_people_page.rb
+++ b/features/page_objects/front_office/registrations/key_people_page.rb
@@ -56,13 +56,6 @@ class KeyPeoplePage < SitePrism::Page
       { first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, dob_day: 1, dob_month: 5, dob_year: 1984 }
     ]
   end
-
-  def dodgy_people
-    [
-      { first_name: "Jane", last_name: "Blogs", dob_day: 1, dob_month: 5, dob_year: 1984 },
-      { first_name: "Fred", last_name: "Blogs", dob_day: 1, dob_month: 5, dob_year: 1984 },
-      { first_name: "Alex", last_name: "Smith-Brown", dob_day: 1, dob_month: 5, dob_year: 1984 }
-    ]
-  end
   # rubocop:enable Layout/LineLength
+
 end

--- a/features/page_objects/front_office/registrations/relevant_people_page.rb
+++ b/features/page_objects/front_office/registrations/relevant_people_page.rb
@@ -62,13 +62,5 @@ class RelevantPeoplePage < SitePrism::Page
       { first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, dob_day: 1, dob_month: 5, dob_year: 1984, position: "Head honcho" }
     ]
   end
-
-  def dodgy_people
-    [
-      { first_name: "Jane", last_name: "Blogs", dob_day: 1, dob_month: 5, dob_year: 1984, position: "Head honcho" },
-      { first_name: "Fred", last_name: "Blogs", dob_day: 1, dob_month: 5, dob_year: 1984, position: "Head honcho" },
-      { first_name: "Alex", last_name: "Smith-Brown", dob_day: 1, dob_month: 5, dob_year: 1984, position: "Head honcho" }
-    ]
-  end
   # rubocop:enable Layout/LineLength
 end

--- a/features/page_objects/front_office/renewals/renew_relevant_people_page.rb
+++ b/features/page_objects/front_office/renewals/renew_relevant_people_page.rb
@@ -60,13 +60,5 @@ class RenewRelevantPeoplePage < SitePrism::Page
       { first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, dob_day: 1, dob_month: 5, dob_year: 1984, position: "Head honcho" }
     ]
   end
-
-  def dodgy_people
-    [
-      { first_name: "Jane", last_name: "Blogs", dob_day: 1, dob_month: 5, dob_year: 1984, position: "Head honcho" },
-      { first_name: "Fred", last_name: "Blogs", dob_day: 1, dob_month: 5, dob_year: 1984, position: "Head honcho" },
-      { first_name: "Alex", last_name: "Smith-Brown", dob_day: 1, dob_month: 5, dob_year: 1984, position: "Head honcho" }
-    ]
-  end
   # rubocop:enable Layout/LineLength
 end

--- a/features/page_objects/journey/company_people_page.rb
+++ b/features/page_objects/journey/company_people_page.rb
@@ -61,13 +61,5 @@ class CompanyPeoplePage < SitePrism::Page
       { first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, dob_day: 1, dob_month: 5, dob_year: 1984 }
     ]
   end
-
-  def dodgy_people
-    [
-      { first_name: "Jane", last_name: "Blogs", dob_day: 1, dob_month: 5, dob_year: 1984 },
-      { first_name: "Fred", last_name: "Blogs", dob_day: 1, dob_month: 5, dob_year: 1984 },
-      { first_name: "Alex", last_name: "Smith-Brown", dob_day: 1, dob_month: 5, dob_year: 1984 }
-    ]
-  end
   # rubocop:enable Layout/LineLength
 end

--- a/features/step_definitions/back_office/general_steps.rb
+++ b/features/step_definitions/back_office/general_steps.rb
@@ -46,11 +46,11 @@ end
 
 Then(/^I will have an upper tier registration$/) do
   expect(@back_app.finish_assisted_page.registration_number).to have_text("CBDU")
-
   expect(@back_app.finish_assisted_page).to have_view_certificate
 
   # Stores registration number and access code for later use
   @reg_number = @back_app.finish_assisted_page.registration_number.text
+  puts @reg_number + " upper tier registration completed on old app"
 
 end
 

--- a/features/step_definitions/front_office/renewal_conviction_check_steps.rb
+++ b/features/step_definitions/front_office/renewal_conviction_check_steps.rb
@@ -31,7 +31,7 @@ When(/^I complete my limited company renewal steps not declaring a conviction$/)
   select_random_upper_tier_options("existing")
   @renewals_app.renewal_information_page.submit
   submit_business_details(@business_name)
-  people = @journey.company_people_page.dodgy_people
+  people = dodgy_people
   @journey.company_people_page.add_main_person(person: people[0])
   @journey.company_people_page.add_main_person(person: people[1])
   @journey.company_people_page.submit_main_person(person: people[2])

--- a/features/step_definitions/journey/registration_steps.rb
+++ b/features/step_definitions/journey/registration_steps.rb
@@ -255,7 +255,7 @@ Given("a key person with a conviction registers as a sole trader upper tier wast
 
   # Store variables for later steps:
   @business_name = "AD UT Sole Trader"
-  @people = @back_app.key_people_page.dodgy_people
+  @people = dodgy_people
 
   step("I want to register as an upper tier carrier")
   step("I start a new registration journey in 'England' as a 'soleTrader'")

--- a/features/support/conviction_helpers.rb
+++ b/features/support/conviction_helpers.rb
@@ -105,3 +105,11 @@ def reject_conviction(reg)
   @bo.convictions_decision_page.submit(conviction_reason: "Test conviction rejected")
   puts reg + " rejected due to convictions"
 end
+
+def dodgy_people
+  [
+    { first_name: "Jane", last_name: "Blogs", dob_day: 1, dob_month: 5, dob_year: 1984, position: "Smooth criminal" },
+    { first_name: "Fred", last_name: "Blogs", dob_day: 1, dob_month: 5, dob_year: 1984, position: "Naughty person" },
+    { first_name: "Alex", last_name: "Smith-Brown", dob_day: 1, dob_month: 5, dob_year: 1984, position: "The Don" }
+  ]
+end


### PR DESCRIPTION
This PR:

- Simplifies the convictions tests, by removing the need to log into the backend
- Moves the `dodgy_people` method to a single helper class to avoid duplication
- Removes more tags which aren't used