### PR TITLE
Set carrier type after seeding

### DIFF
--- a/features/step_definitions/back_office/registration_steps.rb
+++ b/features/step_definitions/back_office/registration_steps.rb
@@ -61,6 +61,8 @@ Then(/^I check the registration details are correct on the back office$/) do
     expect(page_content).to have_text("Lower tier registration - convictions are not applicable")
   end
 
+  @carrier = @seeded_data["registrationType"] if @carrier.blank? && @seeded_data.present?
+
   if @carrier == "carrier_broker_dealer"
     expect(info_panel).to have_text("Carrier, broker and dealer")
   elsif @carrier == "broker_dealer"


### PR DESCRIPTION
We recently made a tweak https://github.com/DEFRA/waste-carriers-acceptance-tests/pull/295 so that when we seed data we also keep a variable holding the registration data from which that registration was created. Hence, in the method which requires a @carrier to be set, when it is nil and we have the registration data from seeding, it will use the carrier type that was set through the seeding.

Closes: https://github.com/DEFRA/waste-carriers-acceptance-tests/issues/296

This will not pass until https://github.com/DEFRA/waste-carriers-back-office/pull/883 is merged. 