### PR TITLE
Update steps and tags so that cards and payments can handle mocking

### DIFF
--- a/features/bo_new/dashboard/order_cards.feature
+++ b/features/bo_new/dashboard/order_cards.feature
@@ -1,17 +1,15 @@
-@bo_new @bo_dashboard @broken
+@bo_new @bo_dashboard
 Feature: [RUBY-767] NCCC agent orders registration cards from back office
   As an NCCC agent
   I want to order registration cards
   So that I can help a waste carrier prove they are registered
-
-  Functionality is currently broken in mock mode!
 
 Background:
 	Given I sign into the back office as "agency-user"
 
 @smoke
 Scenario: NCCC user orders one card by bank card
-  Given I have an active registration
+ Given I have an active registration
   When an agency user orders "1" registration card
    And the agency user pays for the card by bank card
   Then the card order is confirmed with cleared payment
@@ -19,7 +17,7 @@ Scenario: NCCC user orders one card by bank card
    And the carrier receives an email saying their card order is being printed
 
 Scenario: NCCC user orders 3 cards by bank transfer
-  Given I have an active registration
+ Given I have an active registration
   When an agency user orders "3" registration cards
    And the agency user chooses to pay for the card by bank transfer
   Then the card order is confirmed awaiting payment
@@ -38,3 +36,9 @@ Scenario: NCCC user orders 3 cards by bank transfer
   When NCCC pays the remaining balance by "missed_worldpay"
   Then the registration does not have a status of "PAYMENT NEEDED"
    And the registration's balance is 0
+
+Scenario: NCCC orders card but payment is rejected
+ Given I have an active registration with a company name of "Copy card - reject payment"
+  When an agency user orders "1" registration card
+   And I have my credit card payment rejected
+  Then the payment is shown as rejected

--- a/features/fo_new/renewals/payments.feature
+++ b/features/fo_new/renewals/payments.feature
@@ -1,11 +1,10 @@
-@fo_new @fo_renewal @broken
+@fo_new @fo_renewal
 Feature: Registered waste carrier pays for their renewal
   As a carrier of commercial waste
   I want to be able to pay the relevant charge for my renewal
   So that my renewal is completed without any delay
 
-# Need to rewrite these steps so that they work when the mock is in place. Specifically:
-# a payment can be rejected by submitting business details with 'reject' in the name
+  # These steps are built to be bypassed when mocking is in place.
 
     Scenario: Rejected worldpay payment can be paid for on another credit card
       Given mocking is disabled
@@ -28,7 +27,6 @@ Feature: Registered waste carrier pays for their renewal
        Then I will be notified my renewal is pending payment
         And I will receive an email informing me "You need to pay for your waste carriers registration"
 
-# This test can't work if the mock is in place, as there's no cancel option
     Scenario: Cancelled worldpay payment can be paid for by retrying card payment
       Given mocking is disabled
         And I create a new registration as "user@example.com"

--- a/features/step_definitions/front_office/payment_steps.rb
+++ b/features/step_definitions/front_office/payment_steps.rb
@@ -19,19 +19,13 @@ Given(/^I am on the payment page$/) do
 end
 
 When(/^I have my credit card payment rejected$/) do
-  # This step will not work when WorldPay mocking is in place
-  unless mocking_enabled?
-    @renewals_app.payment_summary_page.submit(choice: :card_payment)
-    submit_invalid_card_payment
-  end
+  @renewals_app.payment_summary_page.submit(choice: :card_payment)
+  submit_invalid_card_payment unless mocking_enabled?
 end
 
 When(/^I cancel my credit card payment$/) do
-  # This step will not work when WorldPay mocking is in place
-  unless mocking_enabled?
-    @renewals_app.payment_summary_page.submit(choice: :card_payment)
-    @journey.worldpay_payment_page.cancel_payment
-  end
+  @renewals_app.payment_summary_page.submit(choice: :card_payment)
+  @journey.worldpay_payment_page.cancel_payment unless mocking_enabled?
 end
 
 Then(/^(?:I can pay with another card|I try my credit card payment again)$/) do

--- a/features/step_definitions/journey/order_cards_steps.rb
+++ b/features/step_definitions/journey/order_cards_steps.rb
@@ -82,3 +82,7 @@ Then(/^the carrier receives an email saying they need to pay for their card orde
   visit(Quke::Quke.config.custom["urls"]["last_email_bo"])
   expect(@journey.last_email_page.check_email_for_text(text_to_check)).to be true
 end
+
+Then("the payment is shown as rejected") do
+  expect(@journey.cards_payment_page.error_summary).to have_text("Your payment has been refused")
+end


### PR DESCRIPTION
This PR removed tags and comments which say that steps are broken. Copy cards and payment steps were previously "broken" when WorldPay mocking was in place but this has since been fixed, and we handle a lack of mocks more intelligently now.

It also adds a step to check copy cards for rejected payments, which was fixed in RUBY-1044.

All relevant tests and rubocop pass, although the mocking is still intermittently broken - this will be fixed in RUBY-1040.