### PR TITLE
Revert worldpay during mock

### DIFF
--- a/features/bo_new/dashboard/revert_to_payment_summary.feature
+++ b/features/bo_new/dashboard/revert_to_payment_summary.feature
@@ -1,4 +1,4 @@
-@bo_new @bo_dashboard @wip
+@bo_new @bo_dashboard
 Feature: NCCC agent unblocks a registration from back office
   As an NCCC agent
   I want to unblock a registration using a back office function

--- a/features/bo_new/dashboard/revert_to_payment_summary.feature
+++ b/features/bo_new/dashboard/revert_to_payment_summary.feature
@@ -1,23 +1,21 @@
-@bo_new @bo_dashboard @broken
+@bo_new @bo_dashboard @wip
 Feature: NCCC agent unblocks a registration from back office
   As an NCCC agent
   I want to unblock a registration using a back office function
   So that I can allow the customer to complete their application
 
-  This test will not work if Worldpay mocking is turned on as it relies on the user stopping the journey on the WorldPay page. Fix requested in RUBY-1035.
+  Scenario: NCCC unblocks a stuck registration
+    Given I register and get stuck at the payment stage
+    When I sign into the back office as "agency-user"
+    And I revert the current registration to payment summary
+    Then I can submit the stuck user's application by bank transfer
 
-Background:
-  Given I start a new registration
-   And I complete my application of my limited company as an upper tier waste carrier using my email "user@example.com"
-   And I pay for my application by maestro ordering 0 copy cards
-   And I have signed in the front office using my email
-   And I start renewing my last registration from the frontend
-   And I complete my limited liability partnership renewal steps and get stuck
+  Scenario: NCCC unblocks a stuck renewal
+    Given I have an active registration with a company name of "Stuck renewal test"
+    And I have signed in the front office using my email
+    And I start renewing my last registration from the frontend
+    And I complete the renewal steps and get stuck at the payment stage
 
-Scenario: NCCC unblocks a stuck renewal registration
-  Given I sign into the back office as "agency-user"
-    And I revert the last renewal to payment summary
-  Then the user is able to complete their renewal
-
-# Scenario: NCCC unblock a stuck new registration
-  # pending implementation
+    When I sign into the back office as "agency-user"
+    And I revert the current renewal to payment summary
+    Then I can submit the stuck user's application by bank transfer

--- a/features/fo_new/renewals/payments.feature
+++ b/features/fo_new/renewals/payments.feature
@@ -1,4 +1,4 @@
-@fo_new @fo_renewal
+@fo_new @fo_renew
 Feature: Registered waste carrier pays for their renewal
   As a carrier of commercial waste
   I want to be able to pay the relevant charge for my renewal

--- a/features/fo_new/renewals/renewal_changes.feature
+++ b/features/fo_new/renewals/renewal_changes.feature
@@ -1,4 +1,4 @@
-@fo_new @fo_renewal
+@fo_new @fo_renew
 Feature: Registered waste carrier chooses to renew their registration from start page
   As a carrier of commercial waste
   I want to change my registration details when I renew my waste carriers licence with the Environment Agency

--- a/features/fo_new/renewals/renewal_convictions_checks.feature
+++ b/features/fo_new/renewals/renewal_convictions_checks.feature
@@ -1,4 +1,4 @@
-@fo_new @fo_renewal
+@fo_new @fo_renew
 Feature: Registered waste carrier declares conviction during renewal
   As a member of the waste carriers team in NCCC
   I want to be informed of any potential matches with the Environment Agency's convictions database

--- a/features/fo_new/renewals/renewals.feature
+++ b/features/fo_new/renewals/renewals.feature
@@ -1,4 +1,4 @@
-@fo_new @fo_renewal
+@fo_new @fo_renew
 Feature: Registered waste carrier chooses to renew their registration from registration search
   As a carrier of commercial waste
   I want to renew my waste carriers licence with the Environment Agency

--- a/features/fo_new/renewals/renewals_from_user_registrations_page.feature
+++ b/features/fo_new/renewals/renewals_from_user_registrations_page.feature
@@ -1,4 +1,4 @@
-@fo_new @fo_renewal
+@fo_new @fo_renew
 Feature: Registered waste carrier chooses to renew their registration from registrations account page
   As a carrier of commercial waste
   I want to renew my waste carriers licence with the Environment Agency

--- a/features/page_objects/back_office/new/back_office_app.rb
+++ b/features/page_objects/back_office/new/back_office_app.rb
@@ -114,10 +114,6 @@ class BackOfficeApp
     @last_page = PaymentsPage.new
   end
 
-  def payment_summary_page
-    @last_page = PaymentSummaryPage.new
-  end
-
   def registration_certificate_page
     @last_page = RegistrationCertificatePage.new
   end

--- a/features/page_objects/back_office/new/dashboard_page.rb
+++ b/features/page_objects/back_office/new/dashboard_page.rb
@@ -15,6 +15,7 @@ class DashboardPage < SitePrism::Page
 
   element(:results_table, "table")
   elements(:reg_details_links, "a[href*='/registrations/CBD']")
+  elements(:new_reg_details_links, "a[href*='/new-registrations/")
   elements(:transient_reg_details_links, "a[href*='/renewing-registrations/CBD']")
 
   sections :results, "table tbody tr" do
@@ -31,6 +32,11 @@ class DashboardPage < SitePrism::Page
   def view_reg_details(args = {})
     submit(search_term: args[:search_term])
     reg_details_links[0].click
+  end
+
+  def view_new_reg_details(args = {})
+    submit(search_term: args[:search_term])
+    new_reg_details_links[0].click
   end
 
   def view_transient_reg_details(args = {})

--- a/features/page_objects/back_office/old/back_end_app.rb
+++ b/features/page_objects/back_office/old/back_end_app.rb
@@ -129,10 +129,6 @@ class BackEndApp
     @last_page = OrderPage.new
   end
 
-  def payment_summary_page
-    @last_page = PaymentSummaryPage.new
-  end
-
   def postal_address_page
     @last_page = PostalAddressPage.new
   end

--- a/features/page_objects/front_office/renewals/bank_transfer_page.rb
+++ b/features/page_objects/front_office/renewals/bank_transfer_page.rb
@@ -1,7 +1,8 @@
 class BankTransferPage < SitePrism::Page
 
-  # Pay by bank transfer
+  # Registration takes longer if you pay by bank transfer
 
+  element(:go_back_to_payment_summary_link, "a[href*='confirm-bank-transfer/back']")
   element(:submit_button, "input[type='submit']")
 
   def submit(_args = {})

--- a/features/page_objects/front_office/renewals/renewals_app.rb
+++ b/features/page_objects/front_office/renewals/renewals_app.rb
@@ -28,10 +28,6 @@ class RenewalsApp
     @last_page = OldStartPage.new
   end
 
-  def payment_summary_page
-    @last_page = PaymentSummaryPage.new
-  end
-
   def renewal_information_page
     @last_page = RenewalInformationPage.new
   end

--- a/features/page_objects/journey/journey_app.rb
+++ b/features/page_objects/journey/journey_app.rb
@@ -93,6 +93,10 @@ class JourneyApp
     @last_page = LocationPage.new
   end
 
+  def payment_summary_page
+    @last_page = PaymentSummaryPage.new
+  end
+
   def registration_cards_page
     @last_page = RegistrationCardsPage.new
   end

--- a/features/page_objects/journey/payment_summary_page.rb
+++ b/features/page_objects/journey/payment_summary_page.rb
@@ -1,8 +1,9 @@
 class PaymentSummaryPage < SitePrism::Page
 
   # Payment summary
+
   element(:back_link, "a[href*='back']")
-  element(:heading, :xpath, "//h1[contains(text(), 'Payment summary')]")
+  element(:heading, ".heading-large")
 
   element(:card_payment, "input[value='card']", visible: false)
   element(:bank_transfer_payment, "input[value='bank_transfer']", visible: false)

--- a/features/step_definitions/back_office/edit_steps.rb
+++ b/features/step_definitions/back_office/edit_steps.rb
@@ -49,13 +49,13 @@ When("I edit the most recent registration type to {string}") do |carrier_type|
 end
 
 When("I pay by card") do
-  @bo.payment_summary_page.submit(choice: :card_payment)
+  @journey.payment_summary_page.submit(choice: :card_payment)
 
   submit_valid_card_payment
 end
 
 When("I pay by bank transfer") do
-  @bo.payment_summary_page.submit(choice: :bank_transfer_payment)
+  @journey.payment_summary_page.submit(choice: :bank_transfer_payment)
   @bo.bank_transfer_page.submit
 end
 

--- a/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
@@ -92,7 +92,7 @@ When(/^I renew the local authority registration$/) do
   @journey.address_lookup_page.submit_valid_address
   check_your_answers
   @journey.registration_cards_page.submit
-  @bo.payment_summary_page.submit(choice: :card_payment)
+  @journey.payment_summary_page.submit(choice: :card_payment)
 
   submit_valid_card_payment
 
@@ -125,7 +125,7 @@ When(/^I renew the limited company registration$/) do
   )
   check_your_answers
   @journey.registration_cards_page.submit
-  @bo.payment_summary_page.submit(choice: :card_payment)
+  @journey.payment_summary_page.submit(choice: :card_payment)
 
   submit_valid_card_payment
 
@@ -159,13 +159,10 @@ When(/^I complete the renewal for the account holder$/) do
   submit_business_details(@business_name)
   submit_company_people
   submit_convictions("no convictions")
-  @journey.contact_name_page.submit
-  @journey.contact_phone_page.submit
-  @journey.contact_email_page.submit
-  @journey.address_lookup_page.submit_valid_address
+  submit_existing_contact_details
   check_your_answers
   @journey.registration_cards_page.submit
-  @bo.payment_summary_page.submit(choice: :card_payment)
+  @journey.payment_summary_page.submit(choice: :card_payment)
 
   submit_valid_card_payment
 
@@ -247,7 +244,7 @@ Given(/^I renew the limited company registration declaring a conviction and payi
   @journey.address_lookup_page.submit_valid_address
   check_your_answers
   @journey.registration_cards_page.submit
-  @bo.payment_summary_page.submit(choice: :bank_transfer_payment)
+  @journey.payment_summary_page.submit(choice: :bank_transfer_payment)
   @bo.bank_transfer_page.submit
   @bo.dashboard_page.govuk_banner.home_page.click
 end

--- a/features/step_definitions/back_office/upper_tier/finance_payment_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/finance_payment_steps.rb
@@ -105,7 +105,7 @@ Given(/^the registration has an unsubmitted renewal$/) do
   )
   check_your_answers
   @journey.registration_cards_page.submit
-  @bo.payment_summary_page.submit(choice: :bank_transfer_payment)
+  @journey.payment_summary_page.submit(choice: :bank_transfer_payment)
 end
 
 Then(/^I cannot access payments until the bank transfer option is selected$/) do
@@ -122,7 +122,7 @@ end
 
 When(/^the applicant chooses to pay for the renewal by bank transfer ordering (\d+) copy (?:card|cards)$/) do |copy_card_number|
   order_cards_during_journey(copy_card_number)
-  @bo.payment_summary_page.submit(choice: :bank_transfer_payment)
+  @journey.payment_summary_page.submit(choice: :bank_transfer_payment)
   @bo.bank_transfer_page.submit
 end
 
@@ -132,7 +132,7 @@ And(/^the applicant pays by bank card$/) do
     old_order_cards_during_journey(3)
   else
     order_cards_during_journey(1)
-    @bo.payment_summary_page.submit(choice: :card_payment)
+    @journey.payment_summary_page.submit(choice: :card_payment)
   end
   submit_valid_card_payment
 

--- a/features/step_definitions/back_office/upper_tier/revert_to_payment_summary_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/revert_to_payment_summary_steps.rb
@@ -1,28 +1,65 @@
 require "pry"
 
+When("I register and get stuck at the payment stage") do
+  step("I want to register as an upper tier carrier")
+  step("I start a new registration journey in 'England' as a 'soleTrader'")
+
+  # Generate random business name containing the word "Stuck", to make it searchable later
+  @business_name = "Stuck registration " + rand(1..999_999).to_s
+  step("I complete my registration")
+  @journey.payment_summary_page.submit(choice: :card_payment)
+end
+
 When("I start renewing my last registration from the frontend") do
   @renewals_app = RenewalsApp.new
   @journey = JourneyApp.new
+  @resource_object = :renewal
   @renewals_app.old_start_page.load
   @renewals_app.old_start_page.submit(renewal: true)
   @renewals_app.existing_registration_page.submit(reg_no: @reg_number)
   expect(page).to have_text("You are about to renew registration " + @reg_number)
 end
 
-When("I revert the last renewal to payment summary") do
-  visit_renewal_details_page(@reg_number)
+When("I complete the renewal steps and get stuck at the payment stage") do
+  agree_to_renew_in_england
+  @journey.confirm_business_type_page.submit
+  @journey.tier_check_page.submit(choice: :check_tier)
+  select_random_upper_tier_options("existing")
+  @renewals_app.renewal_information_page.submit
+  submit_business_details(@business_name)
+  submit_company_people
+  submit_convictions("no convictions")
+  submit_existing_contact_details
+  check_your_answers
+  @journey.registration_cards_page.submit
+  @journey.payment_summary_page.submit(choice: :card_payment)
+  # If mocking is turned on and @business_name contains "stuck", user will see a "stuck" page.
+  # If mocking is off, user will see a Worldpay payment screen.
+end
 
+When("I revert the current registration to payment summary") do
+  # Search for registration by name as it doesn't have a CBD number yet:
+  @bo.dashboard_page.view_new_reg_details(search_term: @business_name)
   @bo.registration_details_page.revert_to_payment_summary_link.click
 end
 
-Then("the user is able to complete their renewal") do
-  sign_in_to_front_end_if_necessary(@email_address)
+When("I revert the current renewal to payment summary") do
+  visit_renewal_details_page(@reg_number)
+  @bo.registration_details_page.revert_to_payment_summary_link.click
+end
 
-  @renewals_app.old_start_page.load
-  @renewals_app.old_start_page.submit(renewal: true)
-  @renewals_app.existing_registration_page.submit(reg_no: @reg_number)
-  @renewals_app.payment_summary_page.submit(choice: :card_payment)
-  submit_valid_card_payment
+Then("I can submit the stuck user's application by bank transfer") do
+  # User is already logged in and at the payment summary screen here.
+  # Because mocking works based on the company name, which is already defined by this point, we can't easily
+  # test resubmitting a WorldPay payment here. So this test covers the bank transfer option instead.
 
-  expect(page).to have_content("Renewal complete")
+  step("I pay by bank transfer")
+
+  @reg_number = @journey.confirmation_page.registration_number.text
+  puts @reg_number + " submitted with outstanding payment"
+  if @resource_object == :renewal
+    expect(@journey.confirmation_page).to have_content("Application received")
+  else
+    expect(@journey.confirmation_page).to have_content("You must now pay by bank transfer")
+  end
 end

--- a/features/step_definitions/front_office/payment_steps.rb
+++ b/features/step_definitions/front_office/payment_steps.rb
@@ -9,31 +9,28 @@ Given(/^I am on the payment page$/) do
   submit_business_details(@business_name)
   submit_company_people
   submit_convictions("no convictions")
-  @journey.contact_name_page.submit
-  @journey.contact_phone_page.submit
-  @journey.contact_email_page.submit
-  @journey.address_lookup_page.submit_valid_address
+  submit_existing_contact_details
   check_your_answers
   @journey.registration_cards_page.submit
-  expect(@renewals_app.payment_summary_page.current_url).to include "/payment-summary"
+  expect(@journey.payment_summary_page.current_url).to include "/payment-summary"
 end
 
 When(/^I have my credit card payment rejected$/) do
-  @renewals_app.payment_summary_page.submit(choice: :card_payment)
+  @journey.payment_summary_page.submit(choice: :card_payment)
   submit_invalid_card_payment unless mocking_enabled?
 end
 
 When(/^I cancel my credit card payment$/) do
-  @renewals_app.payment_summary_page.submit(choice: :card_payment)
+  @journey.payment_summary_page.submit(choice: :card_payment)
   @journey.worldpay_payment_page.cancel_payment unless mocking_enabled?
 end
 
 Then(/^(?:I can pay with another card|I try my credit card payment again)$/) do
-  @renewals_app.payment_summary_page.submit(choice: :card_payment)
+  @journey.payment_summary_page.submit(choice: :card_payment)
   submit_valid_card_payment
 end
 
 When(/^I can pay by bank transfer$/) do
-  @renewals_app.payment_summary_page.submit(choice: :bank_transfer_payment)
+  @journey.payment_summary_page.submit(choice: :bank_transfer_payment)
   @renewals_app.bank_transfer_page.submit
 end

--- a/features/step_definitions/front_office/renewal_conviction_check_steps.rb
+++ b/features/step_definitions/front_office/renewal_conviction_check_steps.rb
@@ -17,7 +17,7 @@ When(/^I complete my limited company renewal steps declaring a conviction$/) do
   @journey.address_lookup_page.submit_valid_address
   check_your_answers
   @journey.registration_cards_page.submit
-  @renewals_app.payment_summary_page.submit(choice: :card_payment)
+  @journey.payment_summary_page.submit(choice: :card_payment)
 
   submit_valid_card_payment
 
@@ -45,7 +45,7 @@ When(/^I complete my limited company renewal steps not declaring a conviction$/)
   @journey.address_lookup_page.submit_valid_address
   check_your_answers
   @journey.registration_cards_page.submit
-  @renewals_app.payment_summary_page.submit(choice: :card_payment)
+  @journey.payment_summary_page.submit(choice: :card_payment)
 
   submit_valid_card_payment
 
@@ -70,6 +70,6 @@ When(/^I complete my limited company renewal steps not declaring a company convi
   @journey.address_lookup_page.submit_valid_address
   check_your_answers
   @journey.registration_cards_page.submit
-  @renewals_app.payment_summary_page.submit(choice: :card_payment)
+  @journey.payment_summary_page.submit(choice: :card_payment)
   submit_valid_card_payment
 end

--- a/features/step_definitions/front_office/renewal_steps.rb
+++ b/features/step_definitions/front_office/renewal_steps.rb
@@ -84,6 +84,8 @@ Given(/^I have signed in to renew my registration as "([^"]*)"$/) do |username|
 end
 
 Given(/^I have signed in the front office using my email$/) do
+  # Make email address match seeded data, if not already defined:
+  @email_address ||= "user@example.com"
   sign_in_to_front_end_if_necessary(@email_address)
 end
 
@@ -115,19 +117,10 @@ When(/^I complete my limited company renewal steps$/) do
   submit_business_details(@business_name)
   submit_company_people
   submit_convictions("no convictions")
-  @journey.contact_name_page.submit
-  @journey.contact_phone_page.submit
-  @journey.contact_email_page.submit
-  @journey.address_lookup_page.submit_invalid_address
-  @journey.address_manual_page.submit(
-    house_number: "1",
-    address_line_one: "Test lane",
-    address_line_two: "Testville",
-    city: "Teston"
-  )
+  submit_existing_contact_details
   check_your_answers
   @journey.registration_cards_page.submit
-  @renewals_app.payment_summary_page.submit(choice: :card_payment)
+  @journey.payment_summary_page.submit(choice: :card_payment)
   submit_valid_card_payment
 end
 
@@ -158,16 +151,10 @@ When(/^I complete my sole trader renewal steps$/) do
   people = @journey.company_people_page.main_people
   @journey.company_people_page.submit_main_person(person: people[0])
   submit_convictions("no convictions")
-  @journey.contact_name_page.submit
-  @journey.contact_phone_page.submit
-  @journey.contact_email_page.submit(
-    email: "test@example.com",
-    confirm_email: "test@example.com"
-  )
-  @journey.address_lookup_page.submit_valid_address
+  submit_existing_contact_details
   check_your_answers
   @journey.registration_cards_page.submit
-  @renewals_app.payment_summary_page.submit(choice: :card_payment)
+  @journey.payment_summary_page.submit(choice: :card_payment)
   submit_valid_card_payment
 end
 
@@ -181,13 +168,10 @@ When(/^I complete my local authority renewal steps$/) do
   submit_business_details(@business_name)
   submit_company_people
   submit_convictions("no convictions")
-  @journey.contact_name_page.submit
-  @journey.contact_phone_page.submit
-  @journey.contact_email_page.submit
-  @journey.address_lookup_page.submit_valid_address
+  submit_existing_contact_details
   check_your_answers
   @journey.registration_cards_page.submit
-  @renewals_app.payment_summary_page.submit(choice: :card_payment)
+  @journey.payment_summary_page.submit(choice: :card_payment)
   submit_valid_card_payment
 end
 
@@ -201,33 +185,11 @@ When(/^I complete my limited liability partnership renewal steps$/) do
   submit_business_details(@business_name)
   submit_company_people
   submit_convictions("no convictions")
-  @journey.contact_name_page.submit
-  @journey.contact_phone_page.submit
-  @journey.contact_email_page.submit
-  @journey.address_lookup_page.submit_valid_address
+  submit_existing_contact_details
   check_your_answers
   @journey.registration_cards_page.submit
-  @renewals_app.payment_summary_page.submit(choice: :card_payment)
+  @journey.payment_summary_page.submit(choice: :card_payment)
   submit_valid_card_payment
-end
-
-When(/^I complete my limited liability partnership renewal steps and get stuck$/) do
-  @business_name = "LLP renewal"
-  agree_to_renew_in_england
-  @journey.confirm_business_type_page.submit
-  @journey.tier_check_page.submit(choice: :check_tier)
-  select_random_upper_tier_options("existing")
-  @renewals_app.renewal_information_page.submit
-  submit_business_details(@business_name)
-  submit_company_people
-  submit_convictions("no convictions")
-  @journey.contact_name_page.submit
-  @journey.contact_phone_page.submit
-  @journey.contact_email_page.submit
-  @journey.address_lookup_page.submit_valid_address
-  check_your_answers
-  @journey.registration_cards_page.submit
-  @renewals_app.payment_summary_page.submit(choice: :card_payment)
 end
 
 When(/^I complete my limited liability partnership renewal steps choosing to pay by bank transfer$/) do
@@ -240,13 +202,10 @@ When(/^I complete my limited liability partnership renewal steps choosing to pay
   submit_business_details(@business_name)
   submit_company_people
   submit_convictions("no convictions")
-  @journey.contact_name_page.submit
-  @journey.contact_phone_page.submit
-  @journey.contact_email_page.submit
-  @journey.address_lookup_page.submit_valid_address
+  submit_existing_contact_details
   check_your_answers
   @journey.registration_cards_page.submit
-  @renewals_app.payment_summary_page.submit(choice: :bank_transfer_payment)
+  @journey.payment_summary_page.submit(choice: :bank_transfer_payment)
   @renewals_app.bank_transfer_page.submit
 end
 
@@ -260,13 +219,10 @@ When(/^I complete my partnership renewal steps$/) do
   submit_business_details(@business_name)
   submit_company_people
   submit_convictions("no convictions")
-  @journey.contact_name_page.submit
-  @journey.contact_phone_page.submit
-  @journey.contact_email_page.submit
-  @journey.address_lookup_page.submit_valid_address
+  submit_existing_contact_details
   check_your_answers
   @journey.registration_cards_page.submit
-  @renewals_app.payment_summary_page.submit(choice: :card_payment)
+  @journey.payment_summary_page.submit(choice: :card_payment)
   submit_valid_card_payment
 end
 
@@ -320,7 +276,7 @@ When(/^I complete my overseas company renewal steps$/) do
   )
   check_your_answers
   @journey.registration_cards_page.submit
-  @renewals_app.payment_summary_page.submit(choice: :card_payment)
+  @journey.payment_summary_page.submit(choice: :card_payment)
   submit_valid_card_payment
 end
 

--- a/features/support/renewal_helpers.rb
+++ b/features/support/renewal_helpers.rb
@@ -6,8 +6,14 @@ def start_internal_renewal
   agree_to_renew_in_england
 end
 
-# Reused across several steps
 def agree_to_renew_in_england
   @renewals_app.renewal_start_page.submit
   @journey.location_page.submit(choice: :england)
+end
+
+def submit_existing_contact_details
+  @journey.contact_name_page.submit
+  @journey.contact_phone_page.submit
+  @journey.contact_email_page.submit
+  complete_address_with_random_method
 end


### PR DESCRIPTION
This PR:

1. Allows the existing "revert Worldpay" test to handle mock mode, where if a company name contains "stuck", we simulate a stuck payment screen.
2. Adds a new test to revert Worldpay for new registrations
3. Adds a method to search for a new registration by business name
4. Refactors `payment_summary_page` into the `@journey` app
5. Makes front and back office renewal tags consistent
6. Adds a helper to submit existing contact details for renewals

The whole suite passes, and the new test works with mocking both enabled and disabled. Rubocop is happy.

Fixes #297 
Fixes #311 