### PR TITLE
Test updated start page

### DIFF
--- a/features/fo_new/dashboard/start_page.feature
+++ b/features/fo_new/dashboard/start_page.feature
@@ -1,0 +1,10 @@
+@fo_new @fo_dashboard
+Feature: Waste carrier navigates start page
+  As a carrier of commercial waste
+  I want to register in the appropriate country
+  So that I'm compliant with the law
+
+  Scenario:
+  Given I have reached the GOV.UK start page
+  When I access the links on the page
+  Then I can start my registration

--- a/features/page_objects/front_office/registrations/front_office_app.rb
+++ b/features/page_objects/front_office/registrations/front_office_app.rb
@@ -61,6 +61,10 @@ class FrontOfficeApp
     @last_page = ExistingRegistrationPage.new
   end
 
+  def govuk_start_page
+    @last_page = GovukStartPage.new
+  end
+
   def key_people_page
     @last_page = KeyPeoplePage.new
   end

--- a/features/page_objects/front_office/registrations/govuk_start_page.rb
+++ b/features/page_objects/front_office/registrations/govuk_start_page.rb
@@ -1,0 +1,9 @@
+class GovukStartPage < SitePrism::Page
+
+  # Main entry point into the service.
+  # Not within our team's direct control, but included in regression tests to make sure links are up to date.
+
+  element(:heading, ".gem-c-title__text")
+  element(:start_now_button, ".gem-c-button--bottom-margin")
+
+end

--- a/features/page_objects/front_office/registrations/old_start_page.rb
+++ b/features/page_objects/front_office/registrations/old_start_page.rb
@@ -3,6 +3,7 @@ class OldStartPage < SitePrism::Page
   set_url(Quke::Quke.config.custom["urls"]["front_end"])
 
   # Have you already started an application?
+  element(:heading, "#groupLabel")
   element(:new_registration, "input[value='new']", visible: false)
   element(:renew_registration, "input[value='renew']", visible: false)
 

--- a/features/step_definitions/front_office/general_steps.rb
+++ b/features/step_definitions/front_office/general_steps.rb
@@ -105,3 +105,43 @@ end
 Then(/^I will be told "([^"]*)"$/) do |message|
   expect(@front_app.existing_registration_page).to have_text(message)
 end
+
+Given("I have reached the GOV.UK start page") do
+  @fo = FrontOfficeApp.new
+  visit("https://www.gov.uk/waste-carrier-or-broker-registration")
+  expect(@fo.govuk_start_page.heading).to have_text("Register or renew as a waste carrier, broker or dealer (England)")
+end
+
+When("I access the links on the page") do
+  # Select Wales
+  find_link("Register or renew as a waste carrier, broker or dealer (Wales)").click
+  expect(@fo.govuk_start_page.heading).to have_text("Register or renew as a waste carrier, broker or dealer (Wales)")
+  find_link("Register or renew as a waste carrier, broker or dealer (England)").click
+
+  # Select Scotland
+  find_link("Register or renew as a waste carrier or broker (Scotland)").click
+  expect(@fo.govuk_start_page.heading).to have_text("Register or renew as a waste carrier or broker (Scotland)")
+  page.evaluate_script("window.history.back()")
+
+  # Select Northern Ireland
+  find_link("Register or renew as a waste carrier or broker (Northern Ireland)").click
+  expect(@fo.govuk_start_page.heading).to have_text("Register or renew as a waste carrier or broker (Northern Ireland)")
+  find_link("England").click
+
+  # Select public register
+  find_link("public register of waste carriers, brokers and dealers").click
+  expect(page).to have_text("Choose a register to search")
+  page.evaluate_script("window.history.back()")
+
+  # Select "renew your registration"
+  find_link("renew your registration").click
+  expect(page).to have_text("Is this a new registration?")
+  page.evaluate_script("window.history.back()")
+
+  # Select "Start now"
+  @fo.govuk_start_page.start_now_button.click
+end
+
+Then("I can start my registration") do
+  expect(@fo.old_start_page.heading).to have_text("Is this a new registration?")
+end


### PR DESCRIPTION
This PR tests that the links on the GOV.UK start page are not broken. The test passes in both headless and non-headless mode.

Fixes #277 