### PR TITLE
Renew magic link

### DIFF
--- a/features/bo_new/dashboard/manage_users.feature
+++ b/features/bo_new/dashboard/manage_users.feature
@@ -11,7 +11,7 @@ Scenario: Agency super user adds an agency user then upgrades them
   When the new user accepts their invitation and sets up a password
   Then the new user is logged in
   When I sign into the back office as "agency-super"
-    And I update the new user role to an "agency with refund"
+  And I update the new user role to an "agency with refund"
   Then the new user has the correct back office permissions
 
 Scenario: Agency super user adds and removes an agency user

--- a/features/fo_new/renewals/renew_from_email.feature
+++ b/features/fo_new/renewals/renew_from_email.feature
@@ -1,0 +1,12 @@
+@fo_new @fo_renew
+Feature: Registered waste carrier chooses to renew their registration by email
+  As a carrier of commercial waste
+  I want to renew my waste carriers licence with the Environment Agency
+  So I continue to be compliant with the law
+
+  Scenario: [RUBY-987] Renew from email via magic link
+    Given I create an upper tier registration for my "soleTrader" business as "user@example.com"
+    And I receive an email inviting me to renew
+    When I renew from the email
+    Then I will be notified my renewal is complete
+    And I will receive an email informing me "Your registration as an upper tier waste carrier, broker and dealer has been renewed"

--- a/features/fo_new/renewals/renewals.feature
+++ b/features/fo_new/renewals/renewals.feature
@@ -4,15 +4,6 @@ Feature: Registered waste carrier chooses to renew their registration from regis
   I want to renew my waste carriers licence with the Environment Agency
   So I continue to be compliant with the law
 
-  @email
-  Scenario: Sole trader renews upper tier registration from renewals page
-    Given I create an upper tier registration for my "soleTrader" business as "wcr-user@mailinator.com"
-      And I renew my last registration
-      And I have signed in to renew my registration as "wcr-user@mailinator.com"
-     When I complete my sole trader renewal steps
-     Then I will be notified my renewal is complete
-      And I will receive an email informing me "Your registration as an upper tier waste carrier, broker and dealer has been renewed"
-
   @smoke
   Scenario: Limited liability partnership renews upper tier registration from renewals page
     Given I create an upper tier registration for my "limitedLiabilityPartnership" business as "user@example.com"

--- a/features/page_objects/back_office/new/registration_details_page.rb
+++ b/features/page_objects/back_office/new/registration_details_page.rb
@@ -5,6 +5,7 @@ class RegistrationDetailsPage < SitePrism::Page
   section(:govuk_banner, GovukBanner, GovukBanner::SELECTOR)
 
   element(:back_link, ".link-back")
+  element(:flash_message, ".flash-success")
   element(:heading, ".heading-large")
 
   element(:content, ".column-full")
@@ -16,6 +17,7 @@ class RegistrationDetailsPage < SitePrism::Page
 
   element(:actions_box, ".wcr-actions--push-down")
   element(:renew_link, "a[href*='/ad-privacy-policy?reg_identifier=CBD']")
+  element(:resend_renewal_email_link, "a[href*='/resend-renewal-email']")
   element(:transfer_link, "a[href*='/transfer']")
   element(:edit_link, "a[href*='/edit']")
   element(:view_certificate_link, "a[href*='/certificate']")
@@ -25,6 +27,7 @@ class RegistrationDetailsPage < SitePrism::Page
   element(:cancel_link, "a[href*='/cancels']")
 
   element(:revert_to_payment_summary_link, "a[href$='revert-to-payment-summary']")
+
   # Sample text on this page:
   #
   # Conviction check required

--- a/features/page_objects/journey/last_email_page.rb
+++ b/features/page_objects/journey/last_email_page.rb
@@ -9,8 +9,6 @@ class LastEmailPage < SitePrism::Page
   # The page will be loaded up to 10 times until the email shows
   # (a 1 in 1024 chance of the email not showing).
 
-  set_url Quke::Quke.config.custom["urls"]["last_email_bo"]
-
   element(:email_content, "pre")
 
   # Copy additional functions from WEX tests as needed:

--- a/features/step_definitions/back_office/manage_user_steps.rb
+++ b/features/step_definitions/back_office/manage_user_steps.rb
@@ -30,12 +30,9 @@ Then(/^the new user has the correct back office permissions$/) do
 end
 
 Then("the new user accepts their invitation and sets up a password") do
-  last_email_page = LastEmailPage.new
-  last_email_page.load
+  invitation_email_text = retrieve_email_containing(["Confirm a waste carriers back office account", @new_user_email])
 
-  found_email = last_email_page.check_email_for_text(["Confirm a waste carriers back office account", @new_user_email])
-  expect(found_email).to be(true)
-  @confirm_waste_carriers_email_link = last_email_page.text.match(/.*href\=\\\"(.*)\\\".*/)[1]
+  @confirm_waste_carriers_email_link = invitation_email_text.match(/.*href\=\\\"(.*)\\\".*/)[1]
 
   Capybara.reset_session!
   visit(@confirm_waste_carriers_email_link)

--- a/features/step_definitions/back_office/manage_user_steps.rb
+++ b/features/step_definitions/back_office/manage_user_steps.rb
@@ -30,6 +30,7 @@ Then(/^the new user has the correct back office permissions$/) do
 end
 
 Then("the new user accepts their invitation and sets up a password") do
+  visit(Quke::Quke.config.custom["urls"]["last_email_bo"])
   invitation_email_text = retrieve_email_containing(["Confirm a waste carriers back office account", @new_user_email])
 
   @confirm_waste_carriers_email_link = invitation_email_text.match(/.*href\=\\\"(.*)\\\".*/)[1]

--- a/features/step_definitions/email/email_steps.rb
+++ b/features/step_definitions/email/email_steps.rb
@@ -46,14 +46,8 @@ Given(/^I do not confirm my email address$/) do
 end
 
 Then(/^I will receive an email informing me "([^"]*)"$/) do |text|
-  if @email_app.local?
-    @email_app.mailcatcher_main_page.open_email(1)
-    expect(@email_app.mailcatcher_messages_page).to have_text(text)
-  else
-    @email_app.mailinator_page.load
-    @email_app.mailinator_page.submit(inbox: @email_address)
-    expect(@email_app.mailinator_inbox_page).to have_text(text)
-  end
+  visit(Quke::Quke.config.custom["urls"]["last_email_fo"])
+  expect(retrieve_email_containing([text])).to have_text(text)
 end
 
 Then(/^I will receive a renewal application received email$/) do

--- a/features/step_definitions/journey/registration_steps.rb
+++ b/features/step_definitions/journey/registration_steps.rb
@@ -127,9 +127,11 @@ Given("I create a new registration as {string}") do |account_email|
 end
 
 Given("I create an upper tier registration for my {string} business as {string}") do |business_type, account_email|
+  load_all_apps
   @tier = "upper"
   seed_data = SeedData.new("#{business_type}_complete_active_registration.json", "accountEmail" => account_email)
   @reg_number = seed_data.reg_number
+  @email_address = account_email
   @seeded_data = seed_data.seeded_data
 
   puts "#{business_type} upper tier registration " + @reg_number + " seeded"
@@ -139,9 +141,10 @@ Given("I create a lower tier registration for my {string} business as {string}")
   @tier = "lower"
   seed_data = SeedData.new("lower_#{business_type}_complete_active_registration.json", "accountEmail" => account_email)
   @reg_number = seed_data.reg_number
+  @email_address = account_email
   @seeded_data = seed_data.seeded_data
 
-  puts "#{business_type} lower tier registration " + @reg_number + " seeded"
+  puts "#{business_type} lower tier registration " + @reg_number + " seeded for " + account_email
 end
 
 Given("I have a new registration for a {string} business") do |business_type|

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -126,3 +126,12 @@ def next_year
   time = Time.new
   time.year + 1
 end
+
+def retrieve_email_containing(search_terms)
+  # Search for and return email text containing all the items from the search_terms array.
+  # Assumes that the user has already navigated to the correct front or back office email page.
+  email_was_found = @journey.last_email_page.check_email_for_text(search_terms)
+  return @journey.last_email_page.text if email_was_found
+
+  "Email not found"
+end


### PR DESCRIPTION
This PR covers the first, happy path test for a renewal via email magic link.

Additional paths mentioned in #308 will be covered in a future PR. It also goes part way to removing mailcatcher and mailinator from the suite, which we want to do in #315 .

The new test, plus anything immediately impacted by the email change, passes, and rubocop is happy.