### PR TITLE
Switch Quke branch to main

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "quke",
     git: "https://github.com/defra/quke",
-    branch: "master"
+    branch: "main"
 
 # Rake gives us the ability to create our own commands or 'tasks' for working
 # with quke.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/defra/quke
-  revision: 146e2b63cc4c638ae367ccbab32111ec79cdc984
-  branch: master
+  revision: adb07d14f10b2a3dd3eed3c5ac54a6ad3aa2aaa1
+  branch: main
   specs:
     quke (0.10.0)
       browserstack-local
@@ -19,10 +19,10 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
-    backports (3.17.1)
+    backports (3.17.2)
     browserstack-local (1.3.0)
     builder (3.2.4)
-    capybara (3.32.1)
+    capybara (3.32.2)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -31,9 +31,9 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
-    coderay (1.1.2)
+    coderay (1.1.3)
     concurrent-ruby (1.1.6)
-    cucumber (3.1.2)
+    cucumber (3.2.0)
       builder (>= 2.1.2)
       cucumber-core (~> 3.2.0)
       cucumber-expressions (~> 6.0.1)
@@ -56,7 +56,7 @@ GEM
     faker (2.12.0)
       i18n (>= 1.6, < 2)
     gherkin (5.1.0)
-    i18n (1.8.2)
+    i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     launchy (2.5.0)
       addressable (~> 2.7)
@@ -67,24 +67,24 @@ GEM
     multi_test (0.1.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
-    parallel (1.19.1)
+    parallel (1.19.2)
     parser (2.7.1.3)
       ast (~> 2.4.0)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (4.0.4)
+    public_suffix (4.0.5)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rainbow (3.0.0)
     rake (13.0.1)
-    regexp_parser (1.7.0)
+    regexp_parser (1.7.1)
     rexml (3.2.4)
-    rspec-expectations (3.9.1)
+    rspec-expectations (3.9.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-support (3.9.2)
+    rspec-support (3.9.3)
     rubocop (0.85.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
@@ -107,7 +107,7 @@ GEM
       site_prism-all_there (>= 0.3.1, < 1.0)
     site_prism-all_there (0.3.2)
     unicode-display_width (1.7.0)
-    webdrivers (4.3.0)
+    webdrivers (4.4.1)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)
@@ -126,4 +126,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   2.1.4
+   1.17.3


### PR DESCRIPTION
Because of the work we have been doing to switch our primary branch in our projects to `main` we need to update the reference to the Quke gem.

In my case this meant rebuilding the Gemfile.lock because of an ongoing discrepency with versions of Bundler.