### PR TITLE
Update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
-sudo: false
 language: ruby
-rvm:
-  - 2.4.2
+rvm: 2.4.2
+cache: bundler
 
 # Travis CI clones repositories to a depth of 50 commits, which is only really
 # useful if you are performing git operations.
@@ -9,9 +8,9 @@ rvm:
 git:
   depth: 3
 
-# enable Bundler caching
-# https://docs.travis-ci.com/user/languages/ruby#Caching-Bundler
-cache: bundler
+before_install:
+  - export TZ=UTC
+  - gem install -v 1.17.3 bundler --no-document
 
 # Using the ability to customise the Travis build to check for 'temporary' tags
 # i.e. tags often used when working on a feature/scenario but which we don't
@@ -22,7 +21,8 @@ before_script:
   # If grep returns 0 (match found), test 0 -eq 1 will return 1.
   # If grep returns 1 (no match found), test 1 -eq 1 will return 0.
   # If grep returns 2 (error), test 2 -eq 1 will return 1.
-  # TODO: Re-enable this check. Currently we have a number of scenarios with the
-  # the @wip tag. We captured these initial scenarios here, but as yet have not
-  # had a chance to implement. Once we have then this needs to be uncommented.
   - grep -r --include="*.feature" "@wip\|@focus" features/; test $? -eq 1
+
+script:
+  - bundle exec rubocop
+  - bundle exec rake ci

--- a/Rakefile
+++ b/Rakefile
@@ -1,18 +1,6 @@
 # frozen_string_literal: true
 
-require "rubocop/rake_task"
-
-RuboCop::RakeTask.new
-
 task default: :run
-
-# Remember to create an environment variable in Travis (can be set to anything)!
-if ENV["TRAVIS"]
-  # Setting the default is additive. So if we didn't add the following line
-  # :default would now run both all tests and rubocop
-  Rake::Task[:default].clear
-  task default: [:ci]
-end
 
 desc "Run all scenarios (eq to bundle exec quke)"
 task :run do
@@ -136,7 +124,6 @@ end
 
 desc "Runs the tests used by continuous integration to check the project"
 task :ci do
-  Rake::Task["rubocop"].invoke
   sh %( QUKE_CONFIG=.config-ci.yml bundle exec quke --tags @ci )
 end
 


### PR DESCRIPTION
This updates the travis config to be more consistent with our other ruby based projects.

This includes remove the 'magic' in the Rakefile which handled running on the Travis CI servers. Now its clearer what `bundle exec rake` will do as there is no magic going on behind the scenes.