### PR TITLE
Update seed data request to handle https sites

### DIFF
--- a/features/seeds/seed_data.rb
+++ b/features/seeds/seed_data.rb
@@ -41,7 +41,7 @@ class SeedData
     request = Net::HTTP::Post.new(uri, "Content-Type" => "application/json")
     request.body = data
 
-    Net::HTTP.start(uri.hostname, uri.port) do |http|
+    Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") do |http|
       http.request(request)
     end
   end


### PR DESCRIPTION
When attempting to run a feature against an AWS environment (local testing was fine) that makes a call to `SeedData` I kept getting the following error

```bash
Feature: Cease and revoke registered waste carriers
As an agency user
I need to be able to deregister a registered waste carrier
So that they no longer have a valid waste carrier licence

  Background:                                                         # features/bo_new/dashboard/cease_and_revoke.feature:8
    Given I sign into the back office as "agency-refund-payment-user" # features/step_definitions/back_office/general_steps.rb:15

  Scenario: Agency user can cease upper tier waste carrier licence # features/bo_new/dashboard/cease_and_revoke.feature:11
    Given I have an active registration                            # features/step_definitions/journey/registration_steps.rb:182
      Connection reset by peer (Errno::ECONNRESET)
      <internal:prelude>:78:in `__read_nonblock'
      <internal:prelude>:78:in `read_nonblock'
      ./features/seeds/seed_data.rb:45:in `block in seed'
      ./features/seeds/seed_data.rb:44:in `seed'
      ./features/seeds/seed_data.rb:33:in `response'
      ./features/seeds/seed_data.rb:15:in `reg_number'
      ./features/step_definitions/journey/registration_steps.rb:187:in `"I have an active registration"'
      features/bo_new/dashboard/cease_and_revoke.feature:12:in `Given I have an active registration'
    When the registration is ceased                                # features/step_definitions/back_office/general_steps.rb:124
    Then the registration has a status of "INACTIVE"
```

Specifically `Errno::ECONNRESET`. Some Googling resulted in this could be due to a number of errors. But after some trial and error I found [Ruby request to https - "in read_nonblock': Connection reset by peer (Errno::ECONNRESET)"](https://stackoverflow.com/a/15727341/6117745). The problem here was that when the request was to a site using https, the request itself should also use https else you'll get `ECONNRESET`.

When I made the suggested change, everything started working again! 😁

I'm very much aware @andrewhick and @cintamani have reportedly used this previously without issue. But I had to make this change to get it to work for me. 😕

N.B. Have also tested locally which doesn't use HTTP and it still works there.