### PR TITLE
Unblock and enable renew expired registrations

### DIFF
--- a/config/loc.config.yml
+++ b/config/loc.config.yml
@@ -12,7 +12,7 @@ driver: chrome
 # Let Quke know you want to run the browser in headless mode. Headless mode
 # means the browser still runs but you won't see it displayed. The benefit is
 # that your tests will take less time as it's less resource intensive.
-headless: true
+headless: false
 
 # Add a pause (in seconds) between steps so you can visually track how the
 # browser is responding. Only useful if using a non-headless browser. The

--- a/features/fo_new/renewals/renew_from_email.feature
+++ b/features/fo_new/renewals/renew_from_email.feature
@@ -17,7 +17,6 @@ Feature: Registered waste carrier chooses to renew their registration by email
     When I incorrectly paste its renewal link
     Then I am told the renewal cannot be found
 
-@wip
   Scenario: Renew expired registration just inside grace window
     Given I have a registration which expired 89 days ago
     And I receive an email from NCCC inviting me to renew

--- a/features/fo_new/renewals/renew_from_email.feature
+++ b/features/fo_new/renewals/renew_from_email.feature
@@ -17,8 +17,14 @@ Feature: Registered waste carrier chooses to renew their registration by email
     When I incorrectly paste its renewal link
     Then I am told the renewal cannot be found
 
-# BLOCKED DUE TO https://github.com/DEFRA/waste-carriers-acceptance-tests/issues/317
-#   Scenario: Cannot renew registration outside grace window
-#     Given I have a registration which expired 90 days ago
-#     When I call NCCC to renew it
-#     Then NCCC are unable to generate a renewal email
+@wip
+  Scenario: Renew expired registration just inside grace window
+    Given I have a registration which expired 89 days ago
+    And I receive an email from NCCC inviting me to renew
+    When I renew from the email
+    Then I will be notified my renewal is complete
+
+  Scenario: Cannot renew registration outside grace window
+    Given I have a registration which expired 90 days ago
+    When I call NCCC to renew it
+    Then NCCC are unable to generate a renewal email

--- a/features/seeds/README.md
+++ b/features/seeds/README.md
@@ -79,20 +79,26 @@ This currently might give unwanted results if used with keys that have nested in
 something in the "metaData" of a document, which has a nested piece of json, you can't use this option. Tweaks are possible
 to make it work depending on what the necessities are. Just contact a developer :)
 
-### Custom Expiring date
+### Custom expires_on date
 
-Registrations are automatically set an `expires_on` value by the application that receives the request.
-This date is set to simulate a registration created when the request has been made and is based on specifing settings that are per-environment.
+Registrations are automatically set an `expires_on` date by the back-office seed API if one is not already set in the data it receives.
 
-In order to override this setting, and hence set a custom expire date, you will need to send a document setting custom_expire to some value.
+This is based on the current date plus the config used in its environment. With a standard config this would be the current date plus 3 years.
 
-An example of that, by using options, would be:
+To set the `expire_on` date ensure your `features/seeds/fixtures/my_seed.json` file contains an `expires_on` entry. For example
 
-```ruby
-seed_data = SeedData.new("limitedCompany_complete_active_registration.json", "custom_expire" => 1, "expires_on" => "2021-05-14T10:38:22.692Z")
+```json
+    "declaration" : "1",
+    "expires_on" : "2020-05-14T10:38:17.311Z",
 ```
 
-Alternatively, a json document can be used which has a `expires_on` and `custom_expire` already set.
+That's it! If you wish to use a dynamic date for your `expires_on` (which is advised to avoid 'brittle tests') you can make use of the [Setting any top level attribute](#setting-any-top-level-attribute) to override the one set in the fixture.
+
+```ruby
+  days_ago = 30
+  expiry_date = (DateTime.now - days_ago)
+  seed_data = SeedData.new("limitedCompany_expired_registration.json", "expires_on" => expiry_date.to_s)
+```
 
 ### Copy cards
 

--- a/features/seeds/fixtures/limitedCompany_expired_registration.json
+++ b/features/seeds/fixtures/limitedCompany_expired_registration.json
@@ -1,0 +1,155 @@
+{
+    "tier" : "UPPER",
+    "registrationType" : "carrier_dealer",
+    "businessType" : "limitedCompany",
+    "otherBusinesses" : "no",
+    "constructionWaste" : "yes",
+    "companyName" : "UT Company limited",
+    "firstName" : "Bob",
+    "lastName" : "Carolgees",
+    "phoneNumber" : "0117 4960000",
+    "contactEmail" : "user@example.com",
+    "accountEmail" : "user@example.com",
+    "declaredConvictions" : "no",
+    "declaration" : "1",
+    "metaData" : {
+        "dateRegistered" : "2018-05-14T10:38:17.311Z",
+        "anotherString" : "userDetailAddedAtRegistration",
+        "lastModified" : "2018-05-14T10:38:22.692Z",
+        "dateActivated" : "2018-05-14T10:38:22.692Z",
+        "status" : "EXPIRED",
+        "route" : "DIGITAL",
+        "distance" : "n/a"
+    },
+    "financeDetails" : {
+        "orders" : [
+            {
+                "orderId" : "1526294297",
+                "orderItems" : [
+                    {
+                        "amount" : 15400,
+                        "currency" : "GBP",
+                        "description" : "Initial Registration",
+                        "reference" : "",
+                        "type" : "NEW"
+                    },
+                    {
+                        "amount" : 1000,
+                        "currency" : "GBP",
+                        "description" : "2x Copy cards",
+                        "reference" : "",
+                        "type" : "COPY_CARDS"
+                    }
+                ],
+                "orderCode" : "1526294297",
+                "paymentMethod" : "ONLINE",
+                "merchantId" : "EASERRSIMECOM",
+                "totalAmount" : 16400,
+                "currency" : "GBP",
+                "dateCreated" : "2018-05-14T10:38:18.000Z",
+                "worldPayStatus" : "AUTHORISED",
+                "dateLastUpdated" : "2018-05-14T10:38:22.826Z",
+                "updatedByUser" : "user@example.com",
+                "description" : "New Waste Carrier Registration: CBDU4 for UT Company limited, Plus 2 copy cards"
+            }
+        ],
+        "payments" : [
+            {
+                "orderKey" : "1526294297",
+                "amount" : 16400,
+                "currency" : "GBP",
+                "mac_code" : "fa5f24ee0cb5cb6bc739fc7834ad074b",
+                "dateReceived" : "2018-05-14T10:38:22.675Z",
+                "dateEntered" : "2018-05-14T10:38:22.679Z",
+                "registrationReference" : "Worldpay",
+                "worldPayPaymentStatus" : "AUTHORISED",
+                "updatedByUser" : "user@example.com",
+                "comment" : "Paid via Worldpay",
+                "paymentType" : "WORLDPAY"
+            }
+        ],
+        "balance" : 0
+    },
+    "reg_uuid" : "MEhGfN-GH-2tPVdeqZmbQA",
+    "company_no" : "00445790",
+    "addresses" : [
+        {
+            "uprn" : "200000567267",
+            "addressType" : "REGISTERED",
+            "addressMode" : "address-results",
+            "houseNumber" : "ENVIRONMENT AGENCY",
+            "addressLine1" : "BOW BRIDGE CLOSE",
+            "townCity" : "ROTHERHAM",
+            "postcode" : "BS1 5AH",
+            "country" : "",
+            "dependentLocality" : "",
+            "dependentThoroughfare" : "",
+            "administrativeArea" : "ROTHERHAM",
+            "localAuthorityUpdateDate" : "",
+            "royalMailUpdateDate" : "",
+            "easting" : "442265",
+            "northing" : "391948",
+            "location" : {
+                "lat" : 53.410015,
+                "lon" : -1.339531
+            }
+        },
+        {
+            "addressType" : "POSTAL",
+            "houseNumber" : "ENVIRONMENT AGENCY",
+            "addressLine1" : "BOW BRIDGE CLOSE",
+            "addressLine2" : "",
+            "addressLine3" : "",
+            "addressLine4" : "",
+            "townCity" : "ROTHERHAM",
+            "postcode" : "BS1 5AH",
+            "country" : "",
+            "firstName" : "Bob",
+            "lastName" : "Carolgees"
+        }
+    ],
+    "key_people" : [
+        {
+            "position" : "Director",
+            "first_name" : "Rigoberto",
+            "last_name" : "Mohr",
+            "dob" : "1984-05-01T00:00:00.000Z",
+            "person_type" : "KEY",
+            "conviction_search_result" : {
+                "match_result" : "NO",
+                "searched_at" : "2018-05-14T10:37:54.908Z",
+                "confirmed" : "no"
+            }
+        },
+        {
+            "position" : "Director",
+            "first_name" : "Rosalia",
+            "last_name" : "Mitchell",
+            "dob" : "1984-05-01T00:00:00.000Z",
+            "person_type" : "KEY",
+            "conviction_search_result" : {
+                "match_result" : "NO",
+                "searched_at" : "2018-05-14T10:37:56.303Z",
+                "confirmed" : "no"
+            }
+        },
+        {
+            "position" : "Director",
+            "first_name" : "Haleigh",
+            "last_name" : "Hickle",
+            "dob" : "1984-05-01T00:00:00.000Z",
+            "person_type" : "KEY",
+            "conviction_search_result" : {
+                "match_result" : "NO",
+                "searched_at" : "2018-05-14T10:37:57.529Z",
+                "confirmed" : "no"
+            }
+        }
+    ],
+    "copy_cards" : "2",
+    "conviction_search_result" : {
+        "match_result" : "NO",
+        "searched_at" : "2018-05-14T10:37:50.372Z",
+        "confirmed" : "no"
+    }
+}

--- a/features/seeds/fixtures/limitedCompany_expired_registration.json
+++ b/features/seeds/fixtures/limitedCompany_expired_registration.json
@@ -12,11 +12,12 @@
     "accountEmail" : "user@example.com",
     "declaredConvictions" : "no",
     "declaration" : "1",
+    "expires_on" : "2020-05-14T10:38:17.311Z",
     "metaData" : {
-        "dateRegistered" : "2018-05-14T10:38:17.311Z",
+        "dateRegistered" : "2017-05-14T10:38:17.311Z",
         "anotherString" : "userDetailAddedAtRegistration",
-        "lastModified" : "2018-05-14T10:38:22.692Z",
-        "dateActivated" : "2018-05-14T10:38:22.692Z",
+        "lastModified" : "2017-05-14T10:38:22.692Z",
+        "dateActivated" : "2017-05-14T10:38:22.692Z",
         "status" : "EXPIRED",
         "route" : "DIGITAL",
         "distance" : "n/a"
@@ -46,7 +47,7 @@
                 "merchantId" : "EASERRSIMECOM",
                 "totalAmount" : 16400,
                 "currency" : "GBP",
-                "dateCreated" : "2018-05-14T10:38:18.000Z",
+                "dateCreated" : "2017-05-14T10:38:18.000Z",
                 "worldPayStatus" : "AUTHORISED",
                 "dateLastUpdated" : "2018-05-14T10:38:22.826Z",
                 "updatedByUser" : "user@example.com",
@@ -59,8 +60,8 @@
                 "amount" : 16400,
                 "currency" : "GBP",
                 "mac_code" : "fa5f24ee0cb5cb6bc739fc7834ad074b",
-                "dateReceived" : "2018-05-14T10:38:22.675Z",
-                "dateEntered" : "2018-05-14T10:38:22.679Z",
+                "dateReceived" : "2017-05-14T10:38:22.675Z",
+                "dateEntered" : "2017-05-14T10:38:22.679Z",
                 "registrationReference" : "Worldpay",
                 "worldPayPaymentStatus" : "AUTHORISED",
                 "updatedByUser" : "user@example.com",
@@ -117,7 +118,7 @@
             "person_type" : "KEY",
             "conviction_search_result" : {
                 "match_result" : "NO",
-                "searched_at" : "2018-05-14T10:37:54.908Z",
+                "searched_at" : "2017-05-14T10:37:54.908Z",
                 "confirmed" : "no"
             }
         },
@@ -129,7 +130,7 @@
             "person_type" : "KEY",
             "conviction_search_result" : {
                 "match_result" : "NO",
-                "searched_at" : "2018-05-14T10:37:56.303Z",
+                "searched_at" : "2017-05-14T10:37:56.303Z",
                 "confirmed" : "no"
             }
         },
@@ -141,7 +142,7 @@
             "person_type" : "KEY",
             "conviction_search_result" : {
                 "match_result" : "NO",
-                "searched_at" : "2018-05-14T10:37:57.529Z",
+                "searched_at" : "2017-05-14T10:37:57.529Z",
                 "confirmed" : "no"
             }
         }
@@ -149,7 +150,7 @@
     "copy_cards" : "2",
     "conviction_search_result" : {
         "match_result" : "NO",
-        "searched_at" : "2018-05-14T10:37:50.372Z",
+        "searched_at" : "2017-05-14T10:37:50.372Z",
         "confirmed" : "no"
     }
 }

--- a/features/step_definitions/front_office/renewal_steps.rb
+++ b/features/step_definitions/front_office/renewal_steps.rb
@@ -31,8 +31,18 @@ When("I incorrectly paste its renewal link") do
   visit(renewal_magic_link_for(@reg_number)[0...-1])
 end
 
-Given("I have a registration which expired #{Integer} days ago") do |days_ago|
-  # Requires seeded data with a custom expiry date
+Given("I have a registration which expired {int} days ago") do |days_ago|
+  load_all_apps
+  @tier = "upper"
+  new_expiry_date = (DateTime.now - days_ago).to_s
+  puts "New expiry date = " + new_expiry_date
+
+  seed_data = SeedData.new("limitedCompany_expired_registration.json", "custom_expire" => 1, "expires_on" => new_expiry_date)
+
+  @reg_number = seed_data.reg_number
+  @seeded_data = seed_data.seeded_data
+
+  puts "limitedCompany upper tier expired registration " + @reg_number + " seeded"
 end
 
 When("I call NCCC to renew it") do

--- a/features/step_definitions/front_office/renewal_steps.rb
+++ b/features/step_definitions/front_office/renewal_steps.rb
@@ -41,6 +41,8 @@ Given("I have a registration which expired {int} days ago") do |days_ago|
   @reg_number = seed_data.reg_number
   @seeded_data = seed_data.seeded_data
 
+  @email_address = @seeded_data["contactEmail"]
+
   puts "limitedCompany upper tier expired registration " + @reg_number + " seeded"
 end
 

--- a/features/step_definitions/front_office/renewal_steps.rb
+++ b/features/step_definitions/front_office/renewal_steps.rb
@@ -35,9 +35,8 @@ Given("I have a registration which expired {int} days ago") do |days_ago|
   load_all_apps
   @tier = "upper"
   new_expiry_date = (DateTime.now - days_ago).to_s
-  puts "New expiry date = " + new_expiry_date
 
-  seed_data = SeedData.new("limitedCompany_expired_registration.json", "custom_expire" => 1, "expires_on" => new_expiry_date)
+  seed_data = SeedData.new("limitedCompany_expired_registration.json", "expires_on" => new_expiry_date)
 
   @reg_number = seed_data.reg_number
   @seeded_data = seed_data.seeded_data

--- a/features/support/renewal_helpers.rb
+++ b/features/support/renewal_helpers.rb
@@ -3,7 +3,7 @@
 def send_renewal_email(reg_identifier)
   sign_in_to_back_office("agency-user", false)
   visit_registration_details_page(reg_identifier)
-  sleep 5
+  @bo.registration_details_page.wait_until_resend_renewal_email_link_visible
   @bo.registration_details_page.resend_renewal_email_link.click
 end
 

--- a/features/support/renewal_helpers.rb
+++ b/features/support/renewal_helpers.rb
@@ -3,6 +3,7 @@
 def send_renewal_email(reg_identifier)
   sign_in_to_back_office("agency-user", false)
   visit_registration_details_page(reg_identifier)
+  sleep 5
   @bo.registration_details_page.resend_renewal_email_link.click
 end
 


### PR DESCRIPTION
https://github.com/DEFRA/waste-carriers-acceptance-tests/issues/317

Now we can set custom `expires_on` dates for seeded registrations we can unblock those scenarios that relied on the registration to be renewed having a date either just inside or just outside the renewal grace window.

> Reliant on https://github.com/DEFRA/waste-carriers-back-office/pull/921 being merged first