### PR TITLE
Fix/multipage convictions

### DIFF
--- a/features/fo_new/dashboard/start_page.feature
+++ b/features/fo_new/dashboard/start_page.feature
@@ -1,4 +1,4 @@
-@fo_new @fo_dashboard
+@fo_new @fo_dashboard @wip
 Feature: Waste carrier navigates start page
   As a carrier of commercial waste
   I want to register in the appropriate country

--- a/features/fo_new/dashboard/start_page.feature
+++ b/features/fo_new/dashboard/start_page.feature
@@ -1,4 +1,4 @@
-@fo_new @fo_dashboard @wip
+@fo_new @fo_dashboard
 Feature: Waste carrier navigates start page
   As a carrier of commercial waste
   I want to register in the appropriate country

--- a/features/page_objects/back_office/new/convictions_dashboard_page.rb
+++ b/features/page_objects/back_office/new/convictions_dashboard_page.rb
@@ -12,4 +12,13 @@ class ConvictionsDashboardPage < SitePrism::Page
   element(:approved_tab, "a[href*='/convictions/approved']")
   element(:rejected_tab, "a[href*='/convictions/rejected']")
 
+  def look_for_text(text)
+    # Look for the relevant text on page. If it's not there, click Next and look again.
+    30.times do
+      break if content.has_text?(text)
+
+      find_link("Next ›").click
+    end
+  end
+
 end

--- a/features/page_objects/journey/journey_app.rb
+++ b/features/page_objects/journey/journey_app.rb
@@ -102,10 +102,6 @@ class JourneyApp
     @last_page = PaymentBankTransferPage.new
   end
 
-  def payment_receipt_page
-    @last_page = PaymentReceiptPage.new
-  end
-
   def payment_summary_page
     @last_page = PaymentSummaryPage.new
   end

--- a/features/page_objects/journey/payment_summary_page.rb
+++ b/features/page_objects/journey/payment_summary_page.rb
@@ -7,6 +7,7 @@ class PaymentSummaryPage < SitePrism::Page
   element(:heading, ".heading-large")
 
   element(:card_payment, "input[value='card']", visible: false)
+  element(:receipt_email_field, "#receipt_email_form_receipt_email")
   element(:bank_transfer_payment, "input[value='bank_transfer']", visible: false)
 
   element(:charge, "#registration_registration_fee")
@@ -16,6 +17,7 @@ class PaymentSummaryPage < SitePrism::Page
     case args[:choice]
     when :card_payment
       card_payment.click
+      receipt_email_field.set(args[:email]) if args.key?(:email)
     when :bank_transfer_payment
       bank_transfer_payment.click
     end

--- a/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
@@ -12,7 +12,7 @@ Given(/^NCCC partially renews an existing registration with "([^"]*)"$/) do |con
   @resource_object = :renewal
 
   # Search for registration to renew:
-  sign_in_to_back_office("agency-user")
+  sign_in_to_back_office("agency-refund-payment-user")
   @bo.dashboard_page.view_reg_details(search_term: @reg_number)
   @bo.registration_details_page.renew_link.click
   start_internal_renewal

--- a/features/step_definitions/front_office/general_steps.rb
+++ b/features/step_definitions/front_office/general_steps.rb
@@ -100,24 +100,27 @@ end
 Given("I have reached the GOV.UK start page") do
   @fo = FrontOfficeApp.new
   visit("https://www.gov.uk/waste-carrier-or-broker-registration")
-  expect(@fo.govuk_start_page.heading).to have_text("Register or renew as a waste carrier, broker or dealer (England)")
+  expect(@fo.govuk_start_page.heading).to have_text("Register or renew as a waste carrier, broker or dealer")
 end
 
 When("I access the links on the page") do
   # Select Wales
-  find_link("Register or renew as a waste carrier, broker or dealer (Wales)").click
-  expect(@fo.govuk_start_page.heading).to have_text("Register or renew as a waste carrier, broker or dealer (Wales)")
-  find_link("Register or renew as a waste carrier, broker or dealer (England)").click
+  find_link("Wales").click
+  expect(page).to have_text("Register or renew as a waste carrier, broker or dealer")
+  expect(page).to have_text("If your business is based in Wales, you must register with us")
+  page.evaluate_script("window.history.back()")
 
   # Select Scotland
-  find_link("Register or renew as a waste carrier or broker (Scotland)").click
-  expect(@fo.govuk_start_page.heading).to have_text("Register or renew as a waste carrier or broker (Scotland)")
+  find_link("Scotland").click
+  expect(page).to have_text("Waste carriers and brokers")
+  expect(page).to have_text("Waste Management Licensing (Scotland) Regulations 2011")
   page.evaluate_script("window.history.back()")
 
   # Select Northern Ireland
-  find_link("Register or renew as a waste carrier or broker (Northern Ireland)").click
-  expect(@fo.govuk_start_page.heading).to have_text("Register or renew as a waste carrier or broker (Northern Ireland)")
-  find_link("England").click
+  find_link("Northern Ireland").click
+  expect(page).to have_text("Registration of carriers and brokers")
+  expect(page).to have_text("Information on how to register as a carrier or broker of waste with the Northern Ireland Environment Agency")
+  page.evaluate_script("window.history.back()")
 
   # Select public register
   find_link("public register of waste carriers, brokers and dealers").click

--- a/features/step_definitions/journey/validation_steps.rb
+++ b/features/step_definitions/journey/validation_steps.rb
@@ -108,8 +108,6 @@ Given("I generate errors throughout the journey") do
   expect(@journey.registration_cards_page.error_summary).to have_text("Enter 0 or a number between 1 and 999")
   @journey.registration_cards_page.submit(cards: 3)
 
-  @journey.payment_receipt_page.submit # no validation needed here as we're removing this page soon
-
   @journey.payment_summary_page.submit
   expect(@journey.payment_summary_page.error_summary).to have_text("You must select a payment method")
   @journey.payment_summary_page.submit(choice: :card_payment)

--- a/features/support/conviction_helpers.rb
+++ b/features/support/conviction_helpers.rb
@@ -1,7 +1,5 @@
 def approve_conviction_immediately_for_reg(reg, company_name)
-  go_to_conviction_dashboard
-  expect(@bo.convictions_dashboard_page.content).to have_text(company_name)
-
+  check_conviction_matches_for(company_name)
   go_to_conviction_for_reg(reg)
 
   expected_info = "This registration may have matching or declared convictions and requires an initial review"
@@ -11,9 +9,7 @@ def approve_conviction_immediately_for_reg(reg, company_name)
 end
 
 def flag_conviction_for_reg(reg, company_name)
-  go_to_conviction_dashboard
-  expect(@bo.convictions_dashboard_page.content).to have_text(company_name)
-
+  check_conviction_matches_for(company_name)
   go_to_conviction_for_reg(reg)
 
   expected_info = "This registration may have matching or declared convictions and requires an initial review"
@@ -23,10 +19,7 @@ def flag_conviction_for_reg(reg, company_name)
 end
 
 def approve_flagged_conviction_for_reg(reg, company_name)
-  go_to_conviction_dashboard
-  @bo.convictions_dashboard_page.in_progress_tab.click
-  expect(@bo.convictions_dashboard_page.content).to have_text(company_name)
-
+  check_in_progress_convictions_for(company_name)
   go_to_conviction_for_reg(reg)
 
   expected_info = "This registration has been reviewed and flagged as having relevant convictions."
@@ -36,10 +29,7 @@ def approve_flagged_conviction_for_reg(reg, company_name)
 end
 
 def reject_flagged_conviction_for_reg(reg, company_name)
-  go_to_conviction_dashboard
-  @bo.convictions_dashboard_page.in_progress_tab.click
-  expect(@bo.convictions_dashboard_page.content).to have_text(company_name)
-
+  check_in_progress_convictions_for(company_name)
   go_to_conviction_for_reg(reg)
 
   expected_info = "This registration has been reviewed and flagged as having relevant convictions."
@@ -48,9 +38,19 @@ def reject_flagged_conviction_for_reg(reg, company_name)
   reject_conviction(reg)
 end
 
-def go_to_conviction_dashboard
-  sign_in_to_back_office("agency-refund-payment-user")
+def check_conviction_matches_for(text)
+  sign_in_to_back_office("agency-refund-payment-user", false)
   @bo.dashboard_page.govuk_banner.conviction_checks_link.click
+  @bo.convictions_dashboard_page.look_for_text(text)
+  expect(@bo.convictions_dashboard_page.content).to have_text(text)
+end
+
+def check_in_progress_convictions_for(text)
+  sign_in_to_back_office("agency-refund-payment-user", false)
+  @bo.dashboard_page.govuk_banner.conviction_checks_link.click
+  @bo.convictions_dashboard_page.in_progress_tab.click
+  @bo.convictions_dashboard_page.look_for_text(text)
+  expect(@bo.convictions_dashboard_page.content).to have_text(text)
 end
 
 def go_to_conviction_for_reg(reg)

--- a/features/support/journey_helpers.rb
+++ b/features/support/journey_helpers.rb
@@ -295,8 +295,6 @@ def order_cards_during_journey(number_of_cards)
   else
     @journey.registration_cards_page.submit(cards: number_of_cards)
   end
-  # Also select which email to send receipts to. Longer term, this should be a separate method:
-  @journey.payment_receipt_page.submit
 end
 
 def old_complete_registration_from_bo(business, tier, carrier)


### PR DESCRIPTION
This PR:

- Makes the tests on the convictions dashboard work when the data spans more than one page
- Removes the separate "payment receipt" page which has been removed
- Fixes the GOV.UK start page tests which have recently changed

All affected tests and rubocop pass.