### PR TITLE
Update renewal behaviour and toggles

### DIFF
--- a/features/bo_new/dashboard/toggle_features.feature
+++ b/features/bo_new/dashboard/toggle_features.feature
@@ -1,6 +1,6 @@
-@bo_new @bo_dashboard
+@bo_new @bo_dashboard @toggle
 
-Feature: Toggle features
+Feature: [RUBY-1118] Toggle features
 As an developer
 I want to turn features off and on
 So that I can help our contact centre manage demand

--- a/features/fo_new/new_registration/upper_tier.feature
+++ b/features/fo_new/new_registration/upper_tier.feature
@@ -1,4 +1,4 @@
-@fo_new @fo_reg @smoke @minismoke
+@fo_new @fo_reg @smoke
 Feature: A new user registers as an upper tier waste carrier
   As a carrier of commercial waste
   I want to register for an upper tier licence
@@ -7,6 +7,7 @@ Feature: A new user registers as an upper tier waste carrier
   Background:
     Given I want to register as an upper tier carrier
 
+@minismoke
   Scenario: A sole trader registers as an upper tier waste carrier and pays via Worldpay
     When I start a new registration journey in "England" as a "soleTrader"
     And I complete my registration for my business "Happy Path UT Registration"

--- a/features/fo_new/renewals/renew_from_email.feature
+++ b/features/fo_new/renewals/renew_from_email.feature
@@ -1,4 +1,4 @@
-@fo_new @fo_renew
+@fo_new @fo_renew @toggle
 Feature: Registered waste carrier chooses to renew their registration by email
   As a carrier of commercial waste
   I want to renew my waste carriers licence with the Environment Agency
@@ -20,12 +20,14 @@ Feature: Registered waste carrier chooses to renew their registration by email
 
 @email
   Scenario: Renew expired registration just inside grace window
-    Given I have a registration which expired 89 days ago
+    Given I have a registration which expired 179 days ago
     And I receive an email from NCCC inviting me to renew
     When I renew from the email as a "soleTrader"
     Then I will be notified my renewal is complete
 
+@broken
+# Currently broken due to RUBY-1175.
   Scenario: Cannot renew registration outside grace window
-    Given I have a registration which expired 90 days ago
-    When I call NCCC to renew it
-    Then NCCC are unable to generate a renewal email
+    Given I have a registration which expired 180 days ago
+    # When I call NCCC to renew it
+    # Then NCCC are unable to generate a renewal email

--- a/features/fo_new/renewals/renewal_payments.feature
+++ b/features/fo_new/renewals/renewal_payments.feature
@@ -1,4 +1,4 @@
-@fo_new @fo_renew @email
+@fo_new @fo_renew @email @toggle
 Feature: Registered waste carrier pays for their renewal
   As a carrier of commercial waste
   I want to be able to pay the relevant charge for my renewal

--- a/features/page_objects/back_office/new/toggle_features_page.rb
+++ b/features/page_objects/back_office/new/toggle_features_page.rb
@@ -27,8 +27,7 @@ class ToggleFeaturesPage < SitePrism::Page
   def add_all_toggles
     add_new_toggle("new_registration")
     add_new_toggle("api")
-    add_new_toggle("email_reminders")
-    add_new_toggle("renew_via_magic_link")
+    add_new_toggle("renewal_reminders")
     add_new_toggle("use_extended_grace_window")
   end
 
@@ -45,8 +44,7 @@ class ToggleFeaturesPage < SitePrism::Page
   def disable_all_features
     disable_feature("new_registration")
     disable_feature("api")
-    disable_feature("email_reminders")
-    disable_feature("renew_via_magic_link")
+    disable_feature("renewal_reminders")
     disable_feature("use_extended_grace_window")
   end
 
@@ -63,8 +61,7 @@ class ToggleFeaturesPage < SitePrism::Page
   def enable_all_features
     enable_feature("new_registration")
     enable_feature("api")
-    enable_feature("email_reminders")
-    enable_feature("renew_via_magic_link")
+    enable_feature("renewal_reminders")
     enable_feature("use_extended_grace_window")
   end
 

--- a/features/step_definitions/back_office/toggle_feature_steps.rb
+++ b/features/step_definitions/back_office/toggle_feature_steps.rb
@@ -7,9 +7,10 @@ When("I turn all features off") do
 end
 
 Then("the features are no longer available") do
-  # Look for resend renewal email link:
+  # Look for resend renewal email link and magic link at bottom:
   visit_registration_details_page(@reg_number)
   expect(@bo.registration_details_page).to have_no_resend_renewal_email_link
+  expect(@bo.registration_details_page).to have_no_text("Renewal link")
 
   # Go to new registration start page on frontend:
   visit(Quke::Quke.config.custom["urls"]["front_office"] + "/start")
@@ -26,9 +27,10 @@ When("I turn all features on") do
 end
 
 Then("the features are available") do
-  # Look for resend renewal email link:
+  # Look for resend renewal email link and magic link at bottom:
   visit_registration_details_page(@reg_number)
   expect(@bo.registration_details_page).to have_resend_renewal_email_link
+  expect(@bo.registration_details_page).to have_text("Renewal link")
 
   # Go to new registration start page on frontend:
   visit(Quke::Quke.config.custom["urls"]["front_office"] + "/start")

--- a/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/back_office_renewals_steps.rb
@@ -25,7 +25,7 @@ Given(/^NCCC partially renews an existing registration with "([^"]*)"$/) do |con
   submit_business_details(@business_name)
   submit_company_people
   submit_convictions(convictions)
-  submit_contact_details_from_bo
+  submit_contact_details_for_renewal
   check_your_answers
   # User has submitted the declaration and is on the "certificate and registration cards" page
 end
@@ -38,7 +38,7 @@ Given(/^the back office pages show the correct transient renewal details$/) do
   expect(@bo.registration_details_page).to have_text "Application in progress"
   expect(@bo.registration_details_page).to have_continue_as_ad_button
   expect(@bo.registration_details_page.info_panel).to have_text(@business_name)
-  expect(@bo.registration_details_page.content).to have_text("Bob Carolgees")
+  expect(@bo.registration_details_page.content).to have_text("Peek Freans")
   expect(@bo.registration_details_page.content).to have_text("Application still in progress. No finance data yet.")
   expect(@bo.registration_details_page).to have_no_view_certificate_link
 
@@ -83,13 +83,7 @@ When(/^I renew the local authority registration$/) do
   submit_business_details(@business_name)
   submit_company_people
   submit_convictions("no convictions")
-  @journey.contact_name_page.submit
-  @journey.contact_phone_page.submit
-  @journey.contact_email_page.submit(
-    email: "bo-user@example.com",
-    confirm_email: "bo-user@example.com"
-  )
-  @journey.address_lookup_page.submit_valid_address
+  submit_contact_details_for_renewal
   check_your_answers
   order_cards_during_journey(0)
   @journey.payment_summary_page.submit(choice: :card_payment)
@@ -110,13 +104,7 @@ When(/^I renew the limited company registration$/) do
   submit_business_details(@business_name)
   submit_company_people
   submit_convictions("no convictions")
-  @journey.contact_name_page.submit
-  @journey.contact_phone_page.submit
-  @journey.contact_email_page.submit(
-    email: "bo-user@example.com",
-    confirm_email: "bo-user@example.com"
-  )
-  submit_manual_address
+  submit_contact_details_for_renewal
   check_your_answers
   order_cards_during_journey(0)
   @journey.payment_summary_page.submit(choice: :card_payment)
@@ -153,7 +141,7 @@ When(/^I complete the renewal for the account holder$/) do
   submit_business_details(@business_name)
   submit_company_people
   submit_convictions("no convictions")
-  submit_existing_contact_details
+  submit_contact_details_for_renewal
   check_your_answers
   order_cards_during_journey(0)
   @journey.payment_summary_page.submit(choice: :card_payment)
@@ -229,13 +217,7 @@ Given(/^I renew the limited company registration declaring a conviction and payi
   submit_business_details(@business_name)
   submit_company_people
   submit_convictions("convictions")
-  @journey.contact_name_page.submit
-  @journey.contact_phone_page.submit
-  @journey.contact_email_page.submit(
-    email: "bo-user@example.com",
-    confirm_email: "bo-user@example.com"
-  )
-  @journey.address_lookup_page.submit_valid_address
+  submit_contact_details_for_renewal
   check_your_answers
   order_cards_during_journey(0)
   @journey.payment_summary_page.submit(choice: :bank_transfer_payment)

--- a/features/step_definitions/back_office/upper_tier/finance_payment_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/finance_payment_steps.rb
@@ -90,13 +90,7 @@ Given(/^the registration has an unsubmitted renewal$/) do
   submit_business_details(@business_name)
   submit_company_people
   submit_convictions("no convictions")
-  @journey.contact_name_page.submit
-  @journey.contact_phone_page.submit
-  @journey.contact_email_page.submit(
-    email: "bo-user@example.com",
-    confirm_email: "bo-user@example.com"
-  )
-  submit_manual_address
+  submit_contact_details_for_renewal
   check_your_answers
   order_cards_during_journey(0)
   @journey.payment_summary_page.submit(choice: :bank_transfer_payment)

--- a/features/step_definitions/back_office/upper_tier/stuck_registration_steps.rb
+++ b/features/step_definitions/back_office/upper_tier/stuck_registration_steps.rb
@@ -28,7 +28,7 @@ When("I complete the renewal steps and get stuck at the payment stage") do
   submit_business_details(@business_name)
   submit_company_people
   submit_convictions("no convictions")
-  submit_existing_contact_details
+  submit_contact_details_for_renewal
   check_your_answers
   order_cards_during_journey(0)
   @journey.payment_summary_page.submit(choice: :card_payment)

--- a/features/step_definitions/front_office/payment_steps.rb
+++ b/features/step_definitions/front_office/payment_steps.rb
@@ -9,7 +9,7 @@ Given(/^I complete my renewal up to the payment page$/) do
   submit_business_details(@business_name)
   submit_company_people
   submit_convictions("no convictions")
-  submit_existing_contact_details
+  submit_contact_details_for_renewal
   check_your_answers
   order_cards_during_journey(0)
   expect(@journey.payment_summary_page.current_url).to include "/payment-summary"

--- a/features/step_definitions/front_office/renewal_conviction_check_steps.rb
+++ b/features/step_definitions/front_office/renewal_conviction_check_steps.rb
@@ -8,13 +8,7 @@ When(/^I complete my limited company renewal steps declaring a conviction$/) do
   submit_business_details(@business_name)
   submit_company_people
   submit_convictions("convictions")
-  @journey.contact_name_page.submit
-  @journey.contact_phone_page.submit
-  @journey.contact_email_page.submit(
-    email: "test@example.com",
-    confirm_email: "test@example.com"
-  )
-  @journey.address_lookup_page.submit_valid_address
+  submit_contact_details_for_renewal
   check_your_answers
   order_cards_during_journey(0)
   @journey.payment_summary_page.submit(choice: :card_payment)
@@ -36,13 +30,7 @@ When(/^I complete my limited company renewal steps not declaring a conviction$/)
   @journey.company_people_page.add_main_person(person: people[1])
   @journey.company_people_page.submit_main_person(person: people[2])
   submit_convictions("no convictions")
-  @journey.contact_name_page.submit
-  @journey.contact_phone_page.submit
-  @journey.contact_email_page.submit(
-    email: "test@example.com",
-    confirm_email: "test@example.com"
-  )
-  @journey.address_lookup_page.submit_valid_address
+  submit_contact_details_for_renewal
   check_your_answers
   order_cards_during_journey(0)
   @journey.payment_summary_page.submit(choice: :card_payment)
@@ -61,13 +49,7 @@ When(/^I complete my limited company renewal steps not declaring a company convi
   submit_limited_company_details("existing")
   submit_company_people
   submit_convictions("no convictions")
-  @journey.contact_name_page.submit
-  @journey.contact_phone_page.submit
-  @journey.contact_email_page.submit(
-    email: "test@example.com",
-    confirm_email: "test@example.com"
-  )
-  @journey.address_lookup_page.submit_valid_address
+  submit_contact_details_for_renewal
   check_your_answers
   order_cards_during_journey(0)
   @journey.payment_summary_page.submit(choice: :card_payment)

--- a/features/step_definitions/front_office/renewal_steps.rb
+++ b/features/step_definitions/front_office/renewal_steps.rb
@@ -203,7 +203,7 @@ When("I complete my {string} renewal steps") do |business_type|
     submit_company_people
   end
   submit_convictions("no convictions")
-  submit_existing_contact_details
+  submit_contact_details_for_renewal
   check_your_answers
   order_cards_during_journey(0)
   @journey.payment_summary_page.submit(choice: :card_payment)
@@ -220,7 +220,7 @@ When(/^I complete my limited liability partnership renewal steps choosing to pay
   submit_business_details(@business_name)
   submit_company_people
   submit_convictions("no convictions")
-  submit_existing_contact_details
+  submit_contact_details_for_renewal
   check_your_answers
   order_cards_during_journey(0)
   step("I pay by bank transfer")
@@ -245,9 +245,15 @@ When(/^I complete my overseas company renewal steps$/) do
   @journey.company_people_page.submit_main_person(person: people[0])
   submit_convictions("no convictions")
   order_cards_during_journey(0)
-  @journey.contact_name_page.submit
-  @journey.contact_phone_page.submit
-  @journey.contact_email_page.submit
+  @journey.contact_name_page.submit(
+    first_name: "Peter",
+    last_name: "O'Hanrahahanrahan"
+  )
+  @journey.contact_phone_page.submit(phone_number: "0117 4960000")
+  @journey.contact_email_page.submit(
+    email: "overseas-renewal@example.com",
+    confirm_email: "overseas-renewal@example.com"
+  )
   @journey.address_manual_page.submit(
     house_number: "1",
     address_line_one: "Via poerio",

--- a/features/step_definitions/journey/registration_steps.rb
+++ b/features/step_definitions/journey/registration_steps.rb
@@ -409,11 +409,9 @@ Given("I resume the registration as assisted digital") do
   @journey.standard_page.submit
   @journey.declaration_page.submit
   order_cards_during_journey(3)
-  @journey.payment_summary_page.submit(
-    choice: :card_payment,
-    email: @email_address
-  )
+  @journey.payment_summary_page.submit(choice: :card_payment)
   submit_valid_card_payment
   expect(@journey.confirmation_page.heading).to have_text("Registration complete")
   @reg_number = @journey.confirmation_page.registration_number.text
+  puts @reg_number + " resumed and completed as assisted digital"
 end

--- a/features/step_definitions/journey/validation_steps.rb
+++ b/features/step_definitions/journey/validation_steps.rb
@@ -110,7 +110,15 @@ Given("I generate errors throughout the journey") do
 
   @journey.payment_summary_page.submit
   expect(@journey.payment_summary_page.error_summary).to have_text("You must select a payment method")
-  @journey.payment_summary_page.submit(choice: :card_payment)
+  @journey.payment_summary_page.submit(
+    choice: :card_payment,
+    email: ""
+  )
+  expect(@journey.payment_summary_page.error_summary).to have_text("Enter an email address")
+  @journey.payment_summary_page.submit(
+    choice: :card_payment,
+    email: "receipt-email@example.com"
+  )
 
   submit_valid_card_payment
 end
@@ -118,4 +126,7 @@ end
 Then("I am notified that my application has been received") do
   expect(@journey.confirmation_page.heading).to have_text("Application received")
   expect(@journey.confirmation_page.content).to have_text("check your details and let you know whether your application has been successful")
+  expect(@journey.confirmation_page.content).to have_text("receipt-email@example.com")
+  @reg_number = @journey.confirmation_page.registration_number.text
+  puts @reg_number + " submitted and pending convictions"
 end

--- a/features/support/journey_helpers.rb
+++ b/features/support/journey_helpers.rb
@@ -261,16 +261,27 @@ def old_submit_contact_details_from_bo
   # Back office doesn't have the ability to add a contact address for assisted digital renewals
 end
 
-def submit_contact_details_from_bo
-  # For a renewal, all tests currently select existing contact details.
-  # When registrations have moved to the new app, this function will also need to enter new details.
-  @journey.contact_name_page.submit
-  @journey.contact_phone_page.submit
-  @journey.contact_email_page.submit(
-    email: "bo-user@example.com",
-    confirm_email: "bo-user@example.com"
+def submit_contact_details_for_renewal
+  # Contact details are not replayed as per RUBY-1171.
+  last_name_value = @journey.contact_name_page.last_name.value
+  expect(last_name_value).to eq("")
+  @journey.contact_name_page.submit(
+    first_name: "Peek",
+    last_name: "Freans"
   )
-  submit_manual_address
+
+  phone_value = @journey.contact_phone_page.phone_number.value
+  expect(phone_value).to eq("")
+  @journey.contact_phone_page.submit(phone_number: "0117 4960001")
+
+  email_value = @journey.contact_email_page.email.value
+  expect(email_value).to eq("")
+  @journey.contact_email_page.submit(
+    email: "bo-renewal@example.com",
+    confirm_email: "bo-renewal@example.com"
+  )
+
+  complete_address_with_random_method
 end
 
 def old_check_your_answers

--- a/features/support/renewal_helpers.rb
+++ b/features/support/renewal_helpers.rb
@@ -17,10 +17,3 @@ def agree_to_renew_in_england
   @renewals_app.renewal_start_page.submit
   @journey.location_page.submit(choice: :england)
 end
-
-def submit_existing_contact_details
-  @journey.contact_name_page.submit
-  @journey.contact_phone_page.submit
-  @journey.contact_email_page.submit
-  complete_address_with_random_method
-end


### PR DESCRIPTION
This PR:
- Updates the renewal toggles to reflect the fact that they were merged under RUBY-1170
- Updates renewal behaviour to reflect that contact details are no longer replayed, as per RUBY-1171

All tests and rubocop pass.