### PR TITLE
Reinstate grace window tests and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,11 @@ vendor/overcommit_bundle
 ___*
 chromedriver.log
 
+# Ignore all files which may contain customer data
+*.csv
+*.pdf
+*.zip
+
 # Ignore all logfiles and tempfiles.
 *.log
 /log/*

--- a/features/bo_new/register_and_renew/stuck_registrations.feature
+++ b/features/bo_new/register_and_renew/stuck_registrations.feature
@@ -1,4 +1,4 @@
-@bo_new @bo_dashboard
+@bo_new @bo_reg
 Feature: NCCC agent unblocks a stuck registration from back office
   As an NCCC agent
   I want to unblock a registration using a back office function

--- a/features/bo_old/registrations/upper_ad_ltd_registration.feature
+++ b/features/bo_old/registrations/upper_ad_ltd_registration.feature
@@ -9,6 +9,7 @@ Feature: Assisted digital registration of an upper tier Limited company
     And I request assistance with a new registration
     When I have my limited company as a upper tier waste carrier application completed for me
 
+  # Currently broken in mock mode on local, raised as RUBY-1140
   @smoke @minismoke
   Scenario: NCCC successfully registers a limited company for a upper tier waste carriers licence paying by credit card
     When I pay for my application over the phone by maestro ordering 2 copy cards

--- a/features/fo_new/renewals/renew_from_email.feature
+++ b/features/fo_new/renewals/renew_from_email.feature
@@ -25,9 +25,7 @@ Feature: Registered waste carrier chooses to renew their registration by email
     When I renew from the email as a "soleTrader"
     Then I will be notified my renewal is complete
 
-  # Currently broken due to RUBY-1175.
-  @broken
   Scenario: Cannot renew registration outside grace window
     Given I have a registration which expired 180 days ago
-    # When I call NCCC to renew it
-    # Then NCCC are unable to generate a renewal email
+    When I call NCCC to renew it
+    Then NCCC are unable to generate a renewal email

--- a/features/page_objects/back_office/new/sections/govuk_banner.rb
+++ b/features/page_objects/back_office/new/sections/govuk_banner.rb
@@ -5,7 +5,10 @@ class GovukBanner < SitePrism::Section
   SELECTOR ||= "#global-header".freeze
 
   element(:home_page, "#proposition-name")
-  element(:manage_users_link, "a[href='/bo/users']")
-  element(:conviction_checks_link, "a[href='/bo/convictions']")
+  element(:conviction_checks_link, "a[href*='/bo/convictions']")
+  element(:manage_users_link, "a[href*='/bo/users']")
+  element(:letters_link, "a[href*='/bo/letters']")
+  element(:import_convictions_link, "a[href*='/bo/import-convictions']")
+  element(:toggle_features_link, "a[href*='/bo/features/feature-toggles']")
 
 end

--- a/features/step_definitions/back_office/toggle_feature_steps.rb
+++ b/features/step_definitions/back_office/toggle_feature_steps.rb
@@ -7,6 +7,9 @@ When("I turn all features off") do
 end
 
 Then("the features are no longer available") do
+  # Check no 'download letters' link:
+  expect(@bo.dashboard_page.govuk_banner).to have_no_letters_link
+
   # Look for resend renewal email link and magic link at bottom:
   visit_registration_details_page(@reg_number)
   expect(@bo.registration_details_page).to have_no_resend_renewal_email_link
@@ -27,6 +30,9 @@ When("I turn all features on") do
 end
 
 Then("the features are available") do
+  # Check for 'download letters' link:
+  expect(@bo.dashboard_page.govuk_banner).to have_letters_link
+
   # Look for resend renewal email link and magic link at bottom:
   visit_registration_details_page(@reg_number)
   expect(@bo.registration_details_page).to have_resend_renewal_email_link


### PR DESCRIPTION
The renewal grace period tests were previously broken due to a bug which has since been fixed.

This PR:
- Reinstates that test
- Tweaks tags and page objects
- Adds PDF, CSV and ZIP files to the .gitignore file to reduce the risk of files containing customer data being uploaded

All tests and rubocop pass, and I've double checked the changes, so I plan to merge this straight in.