### PR TITLE
Update start page test to new app

### DIFF
--- a/features/fo_old/upper_partnership_registration.feature
+++ b/features/fo_old/upper_partnership_registration.feature
@@ -8,7 +8,6 @@ Feature: Partnership applies for new upper tier registration
     Given I start a new registration
     When I complete my application of my partnership as a upper tier waste carrier
 
-  @email
   Scenario: Partnership successfully registers for a upper tier waste carriers licence paying by credit card
     When I pay for my application by maestro ordering 2 copy cards
     Then I will be registered as an upper tier waste carrier

--- a/features/page_objects/journey/start_page.rb
+++ b/features/page_objects/journey/start_page.rb
@@ -2,6 +2,7 @@ class StartPage < SitePrism::Page
   set_url("#{Quke::Quke.config.custom['urls']['front_office']}/start")
 
   element(:error_summary, ".error-summary")
+  element(:heading, ".heading-large")
 
   element(:new_registration, "input[value='new']", visible: false)
   element(:renew_registration, "input[value='renew']", visible: false)

--- a/features/step_definitions/front_office/general_steps.rb
+++ b/features/step_definitions/front_office/general_steps.rb
@@ -138,5 +138,5 @@ When("I access the links on the page") do
 end
 
 Then("I can start my registration") do
-  expect(@old.old_start_page.heading).to have_text("Is this a new registration?")
+  expect(@journey.start_page.heading).to have_text("Is this a new registration?")
 end


### PR DESCRIPTION
We have just released the new registration journey. This PR updates the start page test to point to the new journey rather than the old one.

The updated test passes - no others are dependent on it. Rubocop also passes.