### PR TITLE
Register outside england

### DIFF
--- a/features/fo/dashboard/outside_england.feature
+++ b/features/fo/dashboard/outside_england.feature
@@ -8,3 +8,8 @@ Feature: Waste carrier navigates start page
     Given I have reached the GOV.UK start page
     When I access the links on the page
     Then I can start my registration
+
+  Scenario: Register elsewhere in UK
+    Given I am based outside England but in the UK
+    When I look at the links for each country
+    Then I can still decide to register in England

--- a/features/page_objects/journey/confirm_business_type_page.rb
+++ b/features/page_objects/journey/confirm_business_type_page.rb
@@ -3,6 +3,7 @@ class ConfirmBusinessTypePage < SitePrism::Page
   # What type of business or organisation are you? - front office
 
   element(:error_summary, ".error-summary")
+  element(:heading, ".heading-large")
 
   elements(:org_types, "input[name='business_type_form[business_type]']", visible: false)
   element(:submit_button, "input[type='submit']", visible: false)

--- a/features/page_objects/journey/location_page.rb
+++ b/features/page_objects/journey/location_page.rb
@@ -7,12 +7,12 @@ class LocationPage < SitePrism::Page
   element(:error_summary, ".error-summary")
 
   elements(:location, "input[name='location_form[location]']", visible: false)
+  element(:heading, ".heading-large")
   element(:england, "input[value='england']", visible: false)
   element(:wales, "input[value='wales']", visible: false)
   element(:scotland, "input[value='scotland']", visible: false)
   element(:northern_ireland, "input[value='northern_ireland']", visible: false)
   element(:overseas, "input[value='overseas']", visible: false)
-  element(:heading, :xpath, "//h1[contains(text(), 'Where is your principal place of business')]")
   element(:submit_button, "input[type='submit']")
 
   def submit(args = {})

--- a/features/step_definitions/front_office/fo_dashboard_steps.rb
+++ b/features/step_definitions/front_office/fo_dashboard_steps.rb
@@ -136,7 +136,6 @@ When("I look at the links for each country") do
   @journey.location_page.submit(choice: :wales)
   expect(@journey.standard_page.heading).to have_text("You can register in Wales")
   find_link("Register or renew as a waste carrier, broker or dealer (Wales)").click
-  #  expect(page).to have_text("Cyfoeth Naturiol Cymru - Dewis Iaith / Natural Resources Wales - Language Select")
   find_link("Cymraeg").click
   expect(page).to have_text("Cofrestru neu adnewyddu fel cludydd, brocer neu ddeliwr gwastraff") # Register as a waste carrier, broker or dealer
   page.evaluate_script("window.history.back()")

--- a/features/step_definitions/front_office/fo_dashboard_steps.rb
+++ b/features/step_definitions/front_office/fo_dashboard_steps.rb
@@ -123,3 +123,45 @@ Then("I can access the footer links") do
     end
   end
 end
+
+Given("I am based outside England but in the UK") do
+  load_all_apps
+  @reg_type = :new_registration
+  @journey.start_page.load
+  @journey.start_page.submit(choice: @reg_type)
+end
+
+When("I look at the links for each country") do
+  # Select Wales
+  @journey.location_page.submit(choice: :wales)
+  expect(@journey.standard_page.heading).to have_text("You can register in Wales")
+  find_link("Register or renew as a waste carrier, broker or dealer (Wales)").click
+  #  expect(page).to have_text("Cyfoeth Naturiol Cymru - Dewis Iaith / Natural Resources Wales - Language Select")
+  find_link("Cymraeg").click
+  expect(page).to have_text("Cofrestru neu adnewyddu fel cludydd, brocer neu ddeliwr gwastraff") # Register as a waste carrier, broker or dealer
+  page.evaluate_script("window.history.back()")
+  page.evaluate_script("window.history.back()")
+  find_link("Back").click
+
+  # Select Scotland
+  @journey.location_page.submit(choice: :scotland)
+  expect(@journey.standard_page.heading).to have_text("You can register in Scotland")
+  find_link("Register or renew as a waste carrier or broker (Scotland)").click
+  expect(page).to have_text("regulated by the Waste Management Licensing (Scotland) Regulations 2011")
+  page.evaluate_script("window.history.back()")
+  find_link("Back").click
+
+  # Select Northern Ireland
+  @journey.location_page.submit(choice: :northern_ireland)
+  expect(@journey.standard_page.heading).to have_text("You can register in Northern Ireland")
+  find_link("Register or renew as a waste carrier, broker or dealer (Northern Ireland)").click
+  expect(page).to have_text("Registration of carriers and brokers")
+  expect(page).to have_text("Information on how to register as a carrier or broker of waste with the Northern Ireland Environment Agency")
+  page.evaluate_script("window.history.back()")
+end
+
+Then("I can still decide to register in England") do
+  expect(@journey.standard_page.heading).to have_text("You can register in Northern Ireland")
+  @journey.standard_page.button.click
+  expect(@journey.confirm_business_type_page.heading).to have_text("What type of business or organisation are you?")
+end


### PR DESCRIPTION
This PR:
- tests all options to register in Wales, Scotland and Northern Ireland
- checks that we are pointing to the right pages on NRW, SEPA and DAERA-NI sites

All tests and Rubocop pass.