### PR TITLE
worldpay refused payment

### DIFF
--- a/features/bo/dashboard/order_cards.feature
+++ b/features/bo/dashboard/order_cards.feature
@@ -37,7 +37,7 @@ Feature: [RUBY-767] NCCC agent orders registration cards from back office
     When NCCC pays the remaining balance by "missed_worldpay"
     Then the registration does not have a status of "PAYMENT NEEDED"
     And the registration's balance is 0
-@wip
+
   Scenario: NCCC orders card but payment is rejected
     Given I have an active registration with a company name of "Copy card - reject payment"
     When an agency user orders "1" registration card

--- a/features/bo/dashboard/order_cards.feature
+++ b/features/bo/dashboard/order_cards.feature
@@ -37,7 +37,7 @@ Feature: [RUBY-767] NCCC agent orders registration cards from back office
     When NCCC pays the remaining balance by "missed_worldpay"
     Then the registration does not have a status of "PAYMENT NEEDED"
     And the registration's balance is 0
-
+@wip
   Scenario: NCCC orders card but payment is rejected
     Given I have an active registration with a company name of "Copy card - reject payment"
     When an agency user orders "1" registration card

--- a/features/step_definitions/back_office/order_cards_steps.rb
+++ b/features/step_definitions/back_office/order_cards_steps.rb
@@ -84,5 +84,6 @@ Then("the carrier receives an email saying they need to pay for their card order
 end
 
 Then("the payment is shown as rejected") do
+  @journey.cards_payment_page.wait_until_submit_button_visible
   expect(@journey.cards_payment_page.error_summary).to have_text("Your payment has been refused")
 end

--- a/features/step_definitions/back_office/order_cards_steps.rb
+++ b/features/step_definitions/back_office/order_cards_steps.rb
@@ -85,5 +85,6 @@ end
 
 Then("the payment is shown as rejected") do
   @journey.cards_payment_page.wait_until_submit_button_visible
+  puts @journey.cards_payment_page.current_url
   expect(@journey.cards_payment_page.error_summary).to have_text("Your payment has been refused")
 end

--- a/features/step_definitions/back_office/order_cards_steps.rb
+++ b/features/step_definitions/back_office/order_cards_steps.rb
@@ -85,6 +85,5 @@ end
 
 Then("the payment is shown as rejected") do
   @journey.cards_payment_page.wait_until_submit_button_visible
-  puts @journey.cards_payment_page.current_url
   expect(@journey.cards_payment_page.error_summary).to have_text("Your payment has been refused")
 end

--- a/features/step_definitions/front_office/payment_steps.rb
+++ b/features/step_definitions/front_office/payment_steps.rb
@@ -17,6 +17,8 @@ end
 When("I have my credit card payment rejected") do
   @journey.payment_summary_page.submit(choice: :card_payment)
   submit_invalid_card_payment unless mocking_enabled?
+  @journey.cards_payment_page.wait_until_submit_button_visible
+  puts @journey.cards_payment_page.current_url
   expect(@journey.payment_summary_page.error_summary).to have_text("Your payment has been refused.")
 end
 

--- a/features/step_definitions/front_office/payment_steps.rb
+++ b/features/step_definitions/front_office/payment_steps.rb
@@ -18,7 +18,6 @@ When("I have my credit card payment rejected") do
   @journey.payment_summary_page.submit(choice: :card_payment)
   submit_invalid_card_payment unless mocking_enabled?
   @journey.cards_payment_page.wait_until_submit_button_visible
-  puts @journey.cards_payment_page.current_url
   expect(@journey.payment_summary_page.error_summary).to have_text("Your payment has been refused.")
 end
 

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -29,7 +29,7 @@ def mocking_enabled?
     puts @_mocking_enabled_response 
   end
 
-  return false if @_mocking_enabled_response.to_s.include?("HTTPNotFound")
+  return false if @_mocking_enabled_response.to_s.include?("HTTPNotFound"||"HTTPBadGateway")
 
   true
 end

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -26,10 +26,10 @@ def mocking_enabled?
     http = Net::HTTP.new(uri.hostname, uri.port, proxy_uri.host, proxy_uri.port)
     request = Net::HTTP::Get.new(uri.request_uri)
     @_mocking_enabled_response ||= http.request(request)
-    puts @_mocking_enabled_response 
+    puts @_mocking_enabled_response.to_s 
   end
   puts @_mocking_enabled_response.to_s.include?("HTTPNotFound"||"HTTPBadGateway")
-  return false if @_mocking_enabled_response.to_s.include?("HTTPNotFound"||"HTTPBadGateway")
+  return false if @_mocking_enabled_response.to_s.include?("HTTP"")
 
   true
 end

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -26,10 +26,10 @@ def mocking_enabled?
     http = Net::HTTP.new(uri.hostname, uri.port, proxy_uri.host, proxy_uri.port)
     request = Net::HTTP::Get.new(uri.request_uri)
     @_mocking_enabled_response ||= http.request(request)
-    puts @_mocking_enabled_response.to_s 
   end
-  puts @_mocking_enabled_response.to_s.include?("HTTPNotFound") || @_mocking_enabled_response.to_s.include?("HTTPBadGateway")
-  return false if @_mocking_enabled_response.to_s.include?("HTTPNotFound") || @_mocking_enabled_response.to_s.include?("HTTPBadGateway")
+  if @_mocking_enabled_response.to_s.include?("HTTPNotFound") || @_mocking_enabled_response.to_s.include?("HTTPBadGateway")
+    return false
+  end
 
   true
 end

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -26,6 +26,7 @@ def mocking_enabled?
     http = Net::HTTP.new(uri.hostname, uri.port, proxy_uri.host, proxy_uri.port)
     request = Net::HTTP::Get.new(uri.request_uri)
     @_mocking_enabled_response ||= http.request(request)
+    puts @_mocking_enabled_response 
   end
 
   return false if @_mocking_enabled_response.to_s.include?("HTTPNotFound")

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -29,7 +29,7 @@ def mocking_enabled?
     puts @_mocking_enabled_response.to_s 
   end
   puts @_mocking_enabled_response.to_s.include?("HTTPNotFound") || @_mocking_enabled_response.to_s.include?("HTTPBadGateway")
-  return false if @_mocking_enabled_response.to_s.include?("HTTPNotFound"||"HTTPBadGateway")
+  return false if @_mocking_enabled_response.to_s.include?("HTTPNotFound") || @_mocking_enabled_response.to_s.include?("HTTPBadGateway")
 
   true
 end

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -28,7 +28,7 @@ def mocking_enabled?
     @_mocking_enabled_response ||= http.request(request)
     puts @_mocking_enabled_response.to_s 
   end
-  puts @_mocking_enabled_response.to_s.include?("HTTPNotFound"||"HTTPBadGateway")
+  puts @_mocking_enabled_response.to_s.include?("HTTPNotFound") || @_mocking_enabled_response.to_s.include?("HTTPBadGateway")
   return false if @_mocking_enabled_response.to_s.include?("HTTPNotFound"||"HTTPBadGateway")
 
   true

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -29,7 +29,7 @@ def mocking_enabled?
     puts @_mocking_enabled_response.to_s 
   end
   puts @_mocking_enabled_response.to_s.include?("HTTPNotFound"||"HTTPBadGateway")
-  return false if @_mocking_enabled_response.to_s.include?("HTTP"")
+  return false if @_mocking_enabled_response.to_s.include?("HTTPNotFound"||"HTTPBadGateway")
 
   true
 end

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -28,7 +28,7 @@ def mocking_enabled?
     @_mocking_enabled_response ||= http.request(request)
     puts @_mocking_enabled_response 
   end
-
+  puts @_mocking_enabled_response.to_s.include?("HTTPNotFound"||"HTTPBadGateway")
   return false if @_mocking_enabled_response.to_s.include?("HTTPNotFound"||"HTTPBadGateway")
 
   true

--- a/features/support/worldpay_helpers.rb
+++ b/features/support/worldpay_helpers.rb
@@ -23,6 +23,7 @@ end
 def submit_invalid_card_payment
   sleep(3)
   expect(@journey.worldpay_payment_page.test_mode_text).to have_text("Test Mode - This is not a live transaction")
+  puts "Rejected payment"
   @journey.worldpay_payment_page.submit(
     card_number: "6759649826438453",
     cardholder_name: "3d.refused",

--- a/features/support/worldpay_helpers.rb
+++ b/features/support/worldpay_helpers.rb
@@ -22,10 +22,6 @@ end
 
 def submit_invalid_card_payment
   sleep(3)
-  # The return clause is called if WorldPay mocking is in place - if so, the payment is skipped and marked as complete.
-  worldpay_page_is_shown = @journey.worldpay_payment_page.has_test_mode_text?
-  return unless worldpay_page_is_shown
-
   expect(@journey.worldpay_payment_page.test_mode_text).to have_text("Test Mode - This is not a live transaction")
   @journey.worldpay_payment_page.submit(
     card_number: "6759649826438453",

--- a/features/support/worldpay_helpers.rb
+++ b/features/support/worldpay_helpers.rb
@@ -23,7 +23,6 @@ end
 def submit_invalid_card_payment
   sleep(3)
   expect(@journey.worldpay_payment_page.test_mode_text).to have_text("Test Mode - This is not a live transaction")
-  puts "Rejected payment"
   @journey.worldpay_payment_page.submit(
     card_number: "6759649826438453",
     cardholder_name: "3d.refused",


### PR DESCRIPTION
Update to refused worldpay payment test to work correctly when world pay is not mocked and run on Jenkins