### PR TITLE
Removing card order scenario

### DIFF
--- a/features/bo/dashboard/order_cards.feature
+++ b/features/bo/dashboard/order_cards.feature
@@ -16,28 +16,6 @@ Feature: [RUBY-767] NCCC agent orders registration cards from back office
     And the registration's balance is 0
     And the carrier receives an email saying their card order is being printed
 
-  @email 
-  Scenario: NCCC user orders 3 cards by bank transfer
-    Given I have an active registration
-    When an agency user orders "3" registration cards
-    And the agency user chooses to pay for the card by bank transfer
-    Then the card order is confirmed awaiting payment
-    And the registration has a status of "PAYMENT NEEDED"
-    And the carrier receives an email saying they need to pay for their card order
-    And the registration's balance is 15
-
-    When NCCC makes a payment of 5 by "transfer"
-    Then the registration has a status of "PAYMENT NEEDED"
-    And the registration's balance is 10
-
-    When NCCC makes a payment of 5 by "postal"
-    Then the registration has a status of "PAYMENT NEEDED"
-    And the registration's balance is 5
-
-    When NCCC pays the remaining balance by "missed_worldpay"
-    Then the registration does not have a status of "PAYMENT NEEDED"
-    And the registration's balance is 0
-
   Scenario: NCCC orders card but payment is rejected
     Given I have an active registration with a company name of "Copy card - reject payment"
     When an agency user orders "1" registration card

--- a/features/step_definitions/back_office/order_cards_steps.rb
+++ b/features/step_definitions/back_office/order_cards_steps.rb
@@ -28,17 +28,6 @@ When(/^the agency user pays for the (?:card|cards) by bank card$/) do
   submit_valid_card_payment
 end
 
-When(/^the agency user chooses to pay for the (?:card|cards) by bank transfer$/) do
-  # This feature will fail if the registration's balance is not 0 at the start of the test.
-  # Reset database if needed.
-  @journey.cards_payment_page.submit(choice: :alternative_payment)
-
-  expect(@journey.standard_page.heading).to have_text("Details for bank transfer")
-  expect(@journey.standard_page.content).to have_text("£" + (@number_of_cards * 5).to_s)
-  expect(@journey.standard_page.content).to have_text("Cards will be sent out after the payment has cleared.")
-  @journey.standard_page.submit_button.click
-end
-
 Then(/^the card order is confirmed with cleared payment$/) do
   expect(@journey.cards_confirmation_page.confirmation_message).to have_text("Order completed.\nPayment has cleared.")
   expect(@journey.cards_confirmation_page).to have_text("£ " + (@number_of_cards * 5).to_s)


### PR DESCRIPTION
Ad-hoc ordering of copy cards is now disabled in the back office.