### PR TITLE
Docker config with headless firefox as default

### DIFF
--- a/config/docker.config.yml
+++ b/config/docker.config.yml
@@ -1,0 +1,90 @@
+# Normally Capybara expects to be testing an in-process Rack application, but
+# we're using it to talk to a remote host. Users of Quke can set what this
+# will be by simply setting `app_host`. You can then use it directly using
+# Capybara `visit('/Main_Page')` or `visit('/')` rather than having to repeat
+# the full url each time
+app_host: 'http://localhost:3000'
+
+# Tells Quke which browser to use for testing. Choices are firefox, chrome, and
+# browserstack, with the default being chrome
+driver: firefox
+
+# Let Quke know you want to run the browser in headless mode. Headless mode
+# means the browser still runs but you won't see it displayed. The benefit is
+# that your tests will take less time as it's less resource intensive.
+headless: true
+
+# Add a pause (in seconds) between steps so you can visually track how the
+# browser is responding. Only useful if using a non-headless browser. The
+# default is 0
+pause: 0
+
+# Specify whether Quke should stop all tests once an error occurs. Useful in
+# Continuous Integration (CI) environments where a quick Yes/No is preferable to
+# a detailed response. By default Quke sets this to false if not set in the
+# config.
+stop_on_error: false
+
+# By default Quke will display web pages where a failure has taken place.
+# A copy of the html is saved and Quke will display it in your default browser.
+# This can be useful to diagnose why something has failed, but there are times
+# you may not want Quke to do this.
+display_failures: false
+
+# Capybara will attempt to find an element for a period of time, rather than
+# immediately failing because the element cannot be found. This defaults to 2
+# seconds. However if the site you are working with is slow or features
+# elements that take some time to load you can increase this default.
+max_wait_time: 10
+
+# If set Quke will tell Cucumber to output to the console using its
+# 'progress' formatter (simply displays a . for each passing scenario and F for
+# each failing one), rather than the default 'pretty' which displays each
+# scenario in detail.
+# If you don't need to see the detail on each run, this might be easier to
+# follow than the detailed output you see using the default 'pretty' print
+# format.
+print_progress: false
+
+# Anything you place under the 'custom' node in the `.config.yml` file will be
+# available within your steps and page objects by calling
+# `Quke::Quke.config.custom`. So using the example below we could access its
+# values in the following ways
+#
+# Quke::Quke.config.custom["default_org_name"] # = "Testy Ltd"
+# Quke::Quke.config.custom["accounts"]["account2"]["username"] # = "john.doe@example.gov.uk"
+# Quke::Quke.config.custom["urls"]["front_office"] # = "http://myservice.service.gov.uk"
+#
+# As long as what you add is valid YAML (check with a tool like
+# http://www.yamllint.com/) Quke will be able to pick it up and make it
+# available in your tests.
+custom:
+  accounts:
+    # Match the property names with the start of each email address, as tests such as sign_in_to_back_office rely on this:
+    agency-user:
+      username: agency-user@wcr.gov.uk
+    agency-refund-payment-user:
+      username: agency-refund-payment-user@wcr.gov.uk
+    agency-super:
+      username: agency-super@wcr.gov.uk
+    data_user:
+      username: data-user@wcr.gov.uk
+    developer:
+      username: developer@wcr.gov.uk
+    finance-admin-user:
+      username: finance-admin-user@wcr.gov.uk
+    finance-user:
+      username: finance-user@wcr.gov.uk
+    finance-super:
+      username: finance-super@wcr.gov.uk
+    waste_carrier:
+      username: user@example.com
+    waste_carrier2:
+      username: another-user@example.com
+  urls:
+    front_office: "http://localhost:3002"
+    back_office: "http://localhost:8001/bo"
+    back_office_sign_in: "http://localhost:8001/bo/users/sign_in"
+    last_email_fo: "http://localhost:3002/fo/email/last-notify-message"
+    last_email_bo: "http://localhost:8001/bo/email/last-notify-message"
+    mock_enabled: "http://localhost:3002/fo/mocks/company/00445790"

--- a/features/hooks/browser_patches.rb
+++ b/features/hooks/browser_patches.rb
@@ -1,0 +1,17 @@
+# Fix Quke's use of deprecated headless! method for Firefox in newer Selenium.
+unless Selenium::WebDriver::Firefox::Options.method_defined?(:headless!)
+  Selenium::WebDriver::Firefox::Options.define_method(:headless!) do
+    add_argument("-headless")
+  end
+end
+
+# Configure Firefox to render JSON responses as raw text in a <pre> tag
+# (like Chrome does), instead of using Firefox's built-in JSON viewer.
+# This ensures page objects that parse JSON via element(:json_data, "pre")
+# work consistently across browsers.
+original_firefox_profile = Quke::DriverConfiguration.instance_method(:firefox_profile)
+Quke::DriverConfiguration.define_method(:firefox_profile) do
+  profile = original_firefox_profile.bind(self).call
+  profile["devtools.jsonview.enabled"] = false
+  profile
+end

--- a/features/page_objects/back_office/registration_certificate_page.rb
+++ b/features/page_objects/back_office/registration_certificate_page.rb
@@ -6,7 +6,7 @@ class RegistrationCertificatePage < BasePage
   element(:heading, ".heading-small")
 
   def certificate_dates_are_correct?(tier, resource_object)
-    time = Time.new
+    time = Time.now.utc
     # The date in the certificate appears as a day (with no number padding) plus a month name, e.g. 1 April
     # See https://apidock.com/ruby/DateTime/strftime for syntax
     day_and_month = "#{time.strftime('%-d')} #{time.strftime('%B')}"

--- a/features/step_definitions/back_office/finance_payment_steps.rb
+++ b/features/step_definitions/back_office/finance_payment_steps.rb
@@ -13,11 +13,13 @@ When("the registration's balance is {float}") do |balance|
 end
 
 Then("the refund has been completed") do
-  # give the system time to receive and process the webhook event
+  # Wait for mock Govpay to transition refund from "submitted" to "success"
+  # (controlled by GOVPAY_REFUND_SUBMITTED_SUCCESS_LAG env var, default 10s)
   sleep 10
-  # This step assumes that any back office user is already logged in
-  # and the payment status is viewable for that registration (which has been submitted)
+  # Navigate to finance details and trigger the refund status check so the
+  # database is updated from "submitted" to "success" before checking balance.
   visit_finance_details_page(@reg_number)
+  @bo.finance_payment_details_page.check_refund_status.click
   check_balance(0)
 
   @reg_balance = 0

--- a/features/step_definitions/back_office/finance_payment_steps.rb
+++ b/features/step_definitions/back_office/finance_payment_steps.rb
@@ -16,10 +16,12 @@ Then("the refund has been completed") do
   # Wait for mock Govpay to transition refund from "submitted" to "success"
   # (controlled by GOVPAY_REFUND_SUBMITTED_SUCCESS_LAG env var, default 10s)
   sleep 10
-  # Navigate to finance details and trigger the refund status check so the
-  # database is updated from "submitted" to "success" before checking balance.
   visit_finance_details_page(@reg_number)
-  @bo.finance_payment_details_page.check_refund_status.click
+  if mocking_enabled?
+    # With mocks enabled we have to trigger the refund status check so the
+    # database is updated from "submitted" to "success" before checking balance.
+    @bo.finance_payment_details_page.check_refund_status.click
+  end
   check_balance(0)
 
   @reg_balance = 0

--- a/features/support/finance_helpers.rb
+++ b/features/support/finance_helpers.rb
@@ -58,7 +58,7 @@ def enter_payment(amount, method)
   @bo.finance_payment_method_page.submit(choice: method.to_sym)
   expect(@bo.finance_payment_input_page).to have_amount
   expect(@bo.finance_payment_input_page.heading).to have_text("payment for #{@reg_number}")
-  time = Time.new
+  time = Time.now.utc
   @bo.finance_payment_input_page.submit(
     amount: amount.to_s,
     day: time.strftime("%d"),


### PR DESCRIPTION
Added dedicated config for docker setup
- headless firefox as the default (tests often fail with recent chrome versions)  
- some minor patches to make it behave in the same way as chrome (no json rendering)
